### PR TITLE
fix: ensure p2p references stored as text

### DIFF
--- a/supabase/migrations/20241015124000_ensure_p2p_reference_text.sql
+++ b/supabase/migrations/20241015124000_ensure_p2p_reference_text.sql
@@ -1,0 +1,4 @@
+-- Ensure p2p_reference column stores human-readable references
+alter table orders
+  alter column p2p_reference drop default,
+  alter column p2p_reference type text using p2p_reference::text;


### PR DESCRIPTION
## Summary
- ensure `p2p_reference` column uses text type so human-readable IDs can be stored

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: 55 errors, 20 warnings)*
- `npm run build` *(interrupted: build compiled but command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f01a37c8327bd052aa1b7624436