### PR TITLE
Handle missing Supabase env variables

### DIFF
--- a/app/dashboard/UserManagement.tsx
+++ b/app/dashboard/UserManagement.tsx
@@ -163,7 +163,7 @@ export default function UserManagement() {
         return;
       }
 
-      const cleanedUsers = data.map(user => ({
+      const cleanedUsers = (data as User[]).map((user) => ({
         ...user,
         full_name: user.full_name || user.email.split('@')[0],
         role: user.role || 'customer'

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,7 +1,7 @@
-export function getEnvVar(key: string): string {
-  const value = process.env[key];
+export function getEnvVar(key: string, defaultValue = ""): string {
+  const value = process.env[key] || defaultValue;
   if (!value) {
-    throw new Error(`Missing environment variable: ${key}`);
+    console.warn(`Missing environment variable: ${key}`);
   }
   return value;
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,7 +5,8 @@ import { getEnvVar } from './env'
 const supabaseUrl = getEnvVar('NEXT_PUBLIC_SUPABASE_URL')
 const supabaseAnonKey = getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY')
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase: any =
+  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null
 
 export type OrderStatus = 'pending' | 'baking' | 'decorating' | 'ready' | 'completed' | 'cancelled'
 


### PR DESCRIPTION
## Summary
- warn instead of throwing when required environment variables are missing
- avoid creating Supabase client without credentials
- fix implicit any in dashboard user mapping

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Parameter 'quote' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68bf719439b483279b729fb98ce99a23