### PR TITLE
Add defensive P2P order handling and retry logic

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -480,21 +480,21 @@ const initSquareCard = useCallback(async () => {
         specialRequests: formData.specialRequests?.trim() || undefined
       });
 
-      if (result.success) {
-        // Limpiar carrito y formulario
-        localStorage.removeItem('bakery-cart');
-        localStorage.removeItem('bakery-order-form');
-
-        setShowSuccess(true);
-        setShowP2PInstructions(false);
-
-        setTimeout(() => {
-          setShowSuccess(false);
-          router.push('/dashboard');
-        }, 3000);
-      } else {
-        throw new Error(result.error || 'Error creando la orden');
+      if (!result || !result.success) {
+        throw new Error(result?.error || 'Error creando la orden');
       }
+
+      // Limpiar carrito y formulario
+      localStorage.removeItem('bakery-cart');
+      localStorage.removeItem('bakery-order-form');
+
+      setShowSuccess(true);
+      setShowP2PInstructions(false);
+
+      setTimeout(() => {
+        setShowSuccess(false);
+        router.push('/dashboard');
+      }, 3000);
     } catch (err: any) {
       console.error('❌ Error confirmando pago P2P:', err);
       showNotification('error', 'Error en el Pedido', err?.message || 'Por favor intenta de nuevo');

--- a/lib/squareConfig.ts
+++ b/lib/squareConfig.ts
@@ -157,7 +157,24 @@ export async function createP2POrder(orderData: {
       userId: orderData.userId && isValidUUID(orderData.userId) ? orderData.userId : undefined,
     };
 
-    const res = await fetch(functionUrl, {
+    async function fetchWithRetry(url: string, options: RequestInit, retries = 3): Promise<Response> {
+      for (let attempt = 0; attempt < retries; attempt++) {
+        try {
+          const res = await fetch(url, options);
+          if (!res.ok) {
+            const txt = await res.text();
+            throw new Error(`HTTP ${res.status}: ${txt}`);
+          }
+          return res;
+        } catch (err) {
+          if (attempt === retries - 1) throw err;
+          await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+        }
+      }
+      throw new Error('Unexpected fetch retry error');
+    }
+
+    const res = await fetchWithRetry(functionUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -168,11 +185,6 @@ export async function createP2POrder(orderData: {
         orderData: sanitizedOrderData,
       }),
     });
-
-    if (!res.ok) {
-      const txt = await res.text();
-      throw new Error(`HTTP ${res.status}: ${txt}`);
-    }
 
     const result = await res.json();
     if (!result?.success) {


### PR DESCRIPTION
## Summary
- validate createP2POrder response before updating UI state
- add retry logic and clearer error handling to P2P order fetch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bf73b55f68832791b19ea14774d690