### PR TITLE
Normalize P2P order date format

### DIFF
--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -76,7 +76,7 @@ serve(async (req) => {
           : `[Pagado con Zelle | Ref: ${p2pRef}]`,
         p2p_reference: p2pRef,
         status: 'pending',                  // esperando confirmación de pago
-        order_date: new Date().toISOString(),
+        order_date: new Date().toISOString().split('T')[0],
         payment_type: orderData.paymentMethod,
         // Marcar como pagado vía Zelle sin requerir comprobación adicional
         payment_status: 'completed',


### PR DESCRIPTION
## Summary
- ensure P2P edge function saves `order_date` as YYYY-MM-DD to match database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required interactive configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0484f4e688327aaf66996df5eeebc