### PR TITLE
Fix env var handling for Supabase and Square configs

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import { createSquarePayment, createP2POrder, p2pPaymentConfig, squareConfig } from '@/lib/squareConfig';
 import Script from 'next/script';
-import { getEnvVar } from '@/lib/env';
 
 interface CartItem {
   id: string;
@@ -61,8 +60,8 @@ useEffect(() => {
     pickupTime: ''
   });
 
-  const appId = getEnvVar('NEXT_PUBLIC_SQUARE_APPLICATION_ID');
-  const locationId = getEnvVar('NEXT_PUBLIC_SQUARE_LOCATION_ID');
+  const appId = process.env.NEXT_PUBLIC_SQUARE_APPLICATION_ID || '';
+  const locationId = process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID || '';
 
   // Inicializar Square después de mostrar el formulario de tarjeta
 const initSquareCard = useCallback(async () => {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,12 +1,16 @@
 
 import { createClient } from '@supabase/supabase-js'
-import { getEnvVar } from './env'
 
-const supabaseUrl = getEnvVar('NEXT_PUBLIC_SUPABASE_URL')
-const supabaseAnonKey = getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY')
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-export const supabase: any =
-  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables'
+  )
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 export type OrderStatus = 'pending' | 'baking' | 'decorating' | 'ready' | 'completed' | 'cancelled'
 


### PR DESCRIPTION
## Summary
- use static `process.env` for Supabase client and Square IDs
- throw clear error when Supabase env vars are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: 54 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c04d3bb38083278eecdc521b5787a2