### PR TITLE
docs: add env configuration instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Environment variables for Rangers Bakery web app
+# Copy this file to `.env.local` and fill in the values.
+
+# Supabase configuration
+NEXT_PUBLIC_SUPABASE_URL="your-supabase-url"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-anon-key"
+SUPABASE_URL="your-supabase-url"
+SUPABASE_ANON_KEY="your-supabase-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="your-supabase-service-role-key"
+SUPABASE_DB_URL="your-supabase-db-url"
+
+# Square configuration
+SQUARE_ENV="your-square-env"
+SQUARE_LOCATION_ID="your-square-location-id"
+SQUARE_APPLICATION_ID="your-square-application-id"
+SQUARE_ACCESS_TOKEN="your-square-access-token"
+NEXT_PUBLIC_SQUARE_LOCATION_ID="your-square-location-id"
+NEXT_PUBLIC_SQUARE_APPLICATION_ID="your-square-application-id"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vscode/
 node_modules/
 next-env.d.ts
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, create a `.env.local` file by copying `.env.example` and filling in the required environment variables. Supabase and Square credentials can be retrieved from your project settings.
+
+After that, run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- add example environment variable file for Supabase and Square
- document env setup in README
- ignore local .env files

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c0584cd5cc8327a4eda86f08c0fc98