### PR TITLE
Use text fields for order references

### DIFF
--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -44,7 +44,7 @@ serve(async (req) => {
       }
 
       // Referencia legible para P2P (se guarda en p2p_reference)
-      const p2pRef = `P2P-${Date.now()}-${crypto.randomUUID()}`
+      const p2pRef = `P2P-${Date.now()}`
       // UUID para la columna id
       const orderId = crypto.randomUUID()
 

--- a/supabase/migrations/20241015124000_ensure_p2p_reference_text.sql
+++ b/supabase/migrations/20241015124000_ensure_p2p_reference_text.sql
@@ -1,4 +1,6 @@
--- Ensure p2p_reference column stores human-readable references
+-- Ensure p2p_reference and payment_reference columns store human-readable references
 alter table orders
   alter column p2p_reference drop default,
-  alter column p2p_reference type text using p2p_reference::text;
+  alter column p2p_reference type text using p2p_reference::text,
+  alter column payment_reference drop default,
+  alter column payment_reference type text using payment_reference::text;


### PR DESCRIPTION
## Summary
- ensure `p2p_reference` and `payment_reference` columns are stored as text
- generate human-readable P2P references while reserving `crypto.randomUUID()` for order IDs

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Missing `NEXT_PUBLIC_SUPABASE_URL`)*

------
https://chatgpt.com/codex/tasks/task_e_68c083175c148327a99cfb79c5f3a658