### PR TITLE
Add payment_type column to orders table

### DIFF
--- a/supabase/migrations/20250101000000_add_payment_type_to_orders.sql
+++ b/supabase/migrations/20250101000000_add_payment_type_to_orders.sql
@@ -1,0 +1,2 @@
+-- Add payment_type column to orders to track payment method
+alter table orders add column if not exists payment_type text;


### PR DESCRIPTION
## Summary
- add SQL migration to introduce `payment_type` on `orders`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b1e712108327a9f690c4a6ddf036