### PR TITLE
Ensure orders always have a customer name

### DIFF
--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -67,7 +67,7 @@ serve(async (req) => {
         // ✅ Deja que PostgreSQL genere el UUID automáticamente
         
         user_id: (userId && isValidUUID(userId)) ? userId : null,
-        customer_name: orderData.customerInfo?.name?.trim() || null,
+        customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
         items: orderData.items || [],

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -123,7 +123,7 @@ serve(async (req) => {
       const orderRecord: Record<string, any> = {
         // NO establezcas 'id' si tu columna es uuid con default
         user_id: (userId && isValidUUID(userId)) ? userId : null,
-        customer_name: orderData.customerInfo?.name?.trim() || null,
+        customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
         items: orderData.items,


### PR DESCRIPTION
## Summary
- default to a generic customer name when order data omits one in P2P payment flow
- apply same fallback for Square payment orders to satisfy database constraint

## Testing
- `npm run lint` *(fails: prompts "How would you like to configure ESLint?" requiring manual setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b38bc9748327bbfcfeffa649f8e4