### PR TITLE
Handle missing customer names when saving orders

### DIFF
--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -67,7 +67,8 @@ serve(async (req) => {
         // ✅ Deja que PostgreSQL genere el UUID automáticamente
         
         user_id: (userId && isValidUUID(userId)) ? userId : null,
-        customer_name: orderData.customerInfo?.name?.trim() || null,
+        // Provide default name to satisfy NOT NULL constraint in the DB
+        customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
         items: orderData.items || [],

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -123,7 +123,8 @@ serve(async (req) => {
       const orderRecord: Record<string, any> = {
         // NO establezcas 'id' si tu columna es uuid con default
         user_id: (userId && isValidUUID(userId)) ? userId : null,
-        customer_name: orderData.customerInfo?.name?.trim() || null,
+        // Ensure a non-null customer_name to satisfy DB constraints
+        customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
         items: orderData.items,


### PR DESCRIPTION
## Summary
- default to a placeholder customer name when none is provided in payment data

## Testing
- `npx eslint supabase/functions/square-payment/index.ts supabase/functions/p2p-payment/index.ts`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0b3a6f7288327b8eb34b1ba4123d2