### PR TITLE
fix: handle missing items in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -149,8 +149,9 @@ export default function DashboardPage() {
 
       const ordersWithUrls = await Promise.all(
         (orders || []).map(async (order: any) => {
+          const itemsArray = Array.isArray(order.items) ? order.items : [];
           const itemsWithUrls = await Promise.all(
-            (order.items || []).map(async (item: any) => {
+            itemsArray.map(async (item: any) => {
               if (item.photoUrl) {
                 const { data: signed } = await supabase.storage
                   .from('temp-uploads')


### PR DESCRIPTION
## Summary
- prevent dashboard crash when order items aren't an array

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c0b8cd75788327a89d45b53a41518c