### PR TITLE
feat: attach authenticated user to orders

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -415,6 +415,12 @@ const initSquareCard = useCallback(async () => {
         throw new Error('Método de pago no válido');
       }
 
+      const { data: { session } } = await supabase.auth.getSession();
+      const userId = session?.user?.id;
+      if (!userId) {
+        throw new Error('User not authenticated');
+      }
+
       // Crear pago con Square usando el token
       const paymentResult = await createSquarePayment({
         amount: parseFloat(calculateTotal()),
@@ -432,7 +438,7 @@ const initSquareCard = useCallback(async () => {
         paymentMethod: selectedPaymentMethod as 'card' | 'apple_pay' | 'google_pay',
         sourceId,
         currency: 'USD',
-        userId: currentUser?.id,
+        userId,
         pickupTime: formData.pickupTime || undefined,
         specialRequests: formData.specialRequests?.trim() || undefined
       });
@@ -471,6 +477,12 @@ const initSquareCard = useCallback(async () => {
     setIsSubmitting(true);
 
     try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const userId = session?.user?.id;
+      if (!userId) {
+        throw new Error('User not authenticated');
+      }
+
       const result = await createP2POrder({
         amount: calculateSubtotal(),
         items: cartItems.map(item => ({
@@ -485,7 +497,7 @@ const initSquareCard = useCallback(async () => {
           email: currentUser?.email || ''
         },
         paymentMethod: 'zelle',
-        userId: currentUser?.id,
+        userId,
         pickupTime: formData.pickupTime || undefined,
         specialRequests: formData.specialRequests?.trim() || undefined
       });

--- a/lib/squareConfig.ts
+++ b/lib/squareConfig.ts
@@ -77,7 +77,7 @@ export interface SquareOrderData {
   // Token returned by Square Web Payments SDK (card / Apple Pay / Google Pay)
   sourceId?: string;
 
-  userId?: string;
+  userId: string;
   pickupTime?: string | null;
   specialRequests?: string | null;
   currency?: 'USD';
@@ -90,10 +90,12 @@ export async function createSquarePayment(orderData: SquareOrderData) {
     if (!supabaseUrl) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
 
     const functionUrl = `${supabaseUrl}/functions/v1/${EDGE_FUNCTIONS.square}`;
+    if (!isValidUUID(orderData.userId)) {
+      throw new Error('Invalid userId');
+    }
 
     const sanitizedOrderData = {
       ...orderData,
-      userId: orderData.userId && isValidUUID(orderData.userId) ? orderData.userId : undefined,
       currency: orderData.currency ?? 'USD',
       // DO NOT send raw card data; we use sourceId from the SDK
     };
@@ -148,7 +150,7 @@ export async function createP2POrder(orderData: {
   items: SquareOrderItem[];
   customerInfo: { name: string; phone: string; email?: string };
   paymentMethod: 'zelle';
-  userId?: string;
+  userId: string;
   pickupTime?: string;
   specialRequests?: string;
 }) {
@@ -157,10 +159,12 @@ export async function createP2POrder(orderData: {
     if (!supabaseUrl) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
 
     const functionUrl = `${supabaseUrl}/functions/v1/${EDGE_FUNCTIONS.p2p}`;
+    if (!isValidUUID(orderData.userId)) {
+      throw new Error('Invalid userId');
+    }
 
     const sanitizedOrderData = {
       ...orderData,
-      userId: orderData.userId && isValidUUID(orderData.userId) ? orderData.userId : undefined,
     };
 
     async function fetchWithRetry(url: string, options: RequestInit, retries = 3): Promise<Response> {

--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -51,9 +51,8 @@ serve(async (req) => {
 
       // Validate userId antes de usar
       const userId = orderData?.userId
-      if (userId && !isValidUUID(userId)) {
-        console.warn('Invalid userId provided, setting to null:', userId)
-        // No lances error, solo usa null
+      if (!userId || !isValidUUID(userId)) {
+        throw new Error('Invalid or missing userId')
       }
 
       // Calcular montos (orderData.amount representa el subtotal)
@@ -66,7 +65,7 @@ serve(async (req) => {
         // ❌ id: orderId,  ← ELIMINAR ESTA LÍNEA
         // ✅ Deja que PostgreSQL genere el UUID automáticamente
         
-        user_id: (userId && isValidUUID(userId)) ? userId : null,
+        user_id: userId,
         // Provide default name to satisfy NOT NULL constraint in the DB
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -115,14 +115,13 @@ serve(async (req) => {
 
       // Validate userId before constructing order record
       const userId = orderData?.userId;
-      if (userId && !isValidUUID(userId)) {
-        console.warn('Invalid userId provided, setting to null:', userId);
-        // No lanzar error, solo usar null
+      if (!userId || !isValidUUID(userId)) {
+        throw new Error('Invalid or missing userId');
       }
 
       const orderRecord: Record<string, any> = {
         // NO establezcas 'id' si tu columna es uuid con default
-        user_id: (userId && isValidUUID(userId)) ? userId : null,
+        user_id: userId,
         // Ensure a non-null customer_name to satisfy DB constraints
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,


### PR DESCRIPTION
## Summary
- send authenticated user id with order submissions
- validate user id in Square and P2P Edge functions before inserting orders

## Testing
- `npx eslint app/order/OrderForm.tsx lib/squareConfig.ts supabase/functions/p2p-payment/index.ts supabase/functions/square-payment/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c0bf10fa788327a0f426ce546ca6da