### PR TITLE
Avoid tax on Zelle payments

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -341,7 +341,7 @@ const initSquareCard = useCallback(async () => {
   };
 
   const calculateTax = () => {
-    return calculateSubtotal() * 0.03;
+    return selectedPaymentMethod === 'zelle' ? 0 : calculateSubtotal() * 0.03;
   };
 
   const calculateTotal = () => {
@@ -790,10 +790,12 @@ const initSquareCard = useCallback(async () => {
                   <span className="text-gray-600">Subtotal:</span>
                   <span>${calculateSubtotal().toFixed(2)}</span>
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Impuesto (3%):</span>
-                  <span>${calculateTax().toFixed(2)}</span>
-                </div>
+                {calculateTax() > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Impuesto (3%):</span>
+                    <span>${calculateTax().toFixed(2)}</span>
+                  </div>
+                )}
                 <div className="flex justify-between font-bold text-lg border-t pt-2">
                   <span>Total:</span>
                   <span className="text-blue-600">${calculateTotal()}</span>
@@ -886,10 +888,12 @@ const initSquareCard = useCallback(async () => {
                   <span className="text-gray-600">Subtotal:</span>
                   <span>${calculateSubtotal().toFixed(2)}</span>
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Impuesto (3%):</span>
-                  <span>${calculateTax().toFixed(2)}</span>
-                </div>
+                {calculateTax() > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Impuesto (3%):</span>
+                    <span>${calculateTax().toFixed(2)}</span>
+                  </div>
+                )}
                 <div className="flex justify-between font-bold text-lg border-t pt-2">
                   <span>Total:</span>
                   <span className="text-pink-600">${calculateTotal()}</span>
@@ -1125,10 +1129,12 @@ const initSquareCard = useCallback(async () => {
                 <span className="text-gray-600">Subtotal:</span>
                 <span>${calculateSubtotal().toFixed(2)}</span>
               </div>
-              <div className="flex justify-between text-sm">
-                <span className="text-gray-600">Impuesto (3%):</span>
-                <span>${calculateTax().toFixed(2)}</span>
-              </div>
+              {calculateTax() > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600">Impuesto (3%):</span>
+                  <span>${calculateTax().toFixed(2)}</span>
+                </div>
+              )}
               <div className="flex justify-between">
                 <span className="text-lg font-bold text-gray-800">Total:</span>
                 <span className="text-lg font-bold text-pink-600">${calculateTotal()}</span>

--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -367,10 +367,12 @@ export default function TrackOrderPage() {
                         <span className="text-gray-600">Subtotal:</span>
                         <span>${order.subtotal.toFixed(2)}</span>
                       </div>
-                      <div className="flex justify-between">
-                        <span className="text-gray-600">Tax (3%):</span>
-                        <span>${order.tax.toFixed(2)}</span>
-                      </div>
+                      {order.tax > 0 && (
+                        <div className="flex justify-between">
+                          <span className="text-gray-600">Tax (3%):</span>
+                          <span>${order.tax.toFixed(2)}</span>
+                        </div>
+                      )}
                       <div className="flex justify-between font-bold text-lg border-t pt-2">
                         <span>Total:</span>
                         <span className="text-pink-600">${order.total.toFixed(2)}</span>

--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -57,8 +57,8 @@ serve(async (req) => {
 
       // Calcular montos (orderData.amount representa el subtotal)
       const subtotal = Number(orderData.amount.toFixed(2))
-      const tax = Number((subtotal * 0.03).toFixed(2))
-      const total = Number((subtotal + tax).toFixed(2))
+      const tax = 0
+      const total = subtotal
 
       // ✅ CORRECCIÓN: NO incluir 'id' en el objeto
       const orderRecord: any = {


### PR DESCRIPTION
## Summary
- Skip 3% tax calculation for Zelle orders and totals
- Hide tax row in order and tracking views when Zelle is selected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d01d6760832783094d5feaee1f2e