### PR TITLE
Ensure order user_id references profiles

### DIFF
--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -55,6 +55,16 @@ serve(async (req) => {
         throw new Error('Invalid or missing userId')
       }
 
+      const { data: profile, error: profileError } = await supabaseAdmin
+        .from('profiles')
+        .select('id')
+        .eq('id', userId)
+        .single()
+
+      if (profileError || !profile?.id) {
+        throw new Error('User profile not found')
+      }
+
       // Calcular montos (orderData.amount representa el subtotal)
       const subtotal = Number(orderData.amount.toFixed(2))
       const tax = 0
@@ -64,8 +74,8 @@ serve(async (req) => {
       const orderRecord: any = {
         // ❌ id: orderId,  ← ELIMINAR ESTA LÍNEA
         // ✅ Deja que PostgreSQL genere el UUID automáticamente
-        
-        user_id: userId,
+
+        user_id: profile.id,
         // Provide default name to satisfy NOT NULL constraint in the DB
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -119,9 +119,19 @@ serve(async (req) => {
         throw new Error('Invalid or missing userId');
       }
 
+      const { data: profile, error: profileError } = await supabaseAdmin
+        .from('profiles')
+        .select('id')
+        .eq('id', userId)
+        .single();
+
+      if (profileError || !profile?.id) {
+        throw new Error('User profile not found');
+      }
+
       const orderRecord: Record<string, any> = {
         // NO establezcas 'id' si tu columna es uuid con default
-        user_id: userId,
+        user_id: profile.id,
         // Ensure a non-null customer_name to satisfy DB constraints
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,


### PR DESCRIPTION
## Summary
- Fetch user profile by ID before inserting orders
- Use profile.id when saving P2P and Square orders

## Testing
- `./node_modules/.bin/eslint supabase/functions/p2p-payment/index.ts supabase/functions/square-payment/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c0dac725ec832782b2506d7b0f3c8a