### PR TITLE
Remove redundant customer info fields from order form

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -56,8 +56,6 @@ useEffect(() => {
   const [addedItems, setAddedItems] = useState<Set<string>>(new Set());
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [formData, setFormData] = useState({
-    fullName: '',
-    phone: '',
     specialRequests: '',
     pickupTime: ''
   });
@@ -214,8 +212,6 @@ const initSquareCard = useCallback(async () => {
     if (savedForm) {
       const parsed = JSON.parse(savedForm);
       setFormData({
-        fullName: parsed.fullName || '',
-        phone: parsed.phone || '',
         specialRequests: parsed.specialRequests || '',
         pickupTime: parsed.pickupTime || ''
       });
@@ -237,25 +233,15 @@ const initSquareCard = useCallback(async () => {
           .select('*')
           .eq('id', user.id)
           .single();
-        
+
         if (profile) {
           setCurrentUser(profile);
-          setFormData(prev => ({
-            ...prev,
-            phone: prev.phone || profile.phone || '',
-            fullName: prev.fullName || profile.full_name || ''
-          }));
         }
       } else {
         const localUser = localStorage.getItem('bakery-user');
         if (localUser) {
           const userData = JSON.parse(localUser);
           setCurrentUser(userData);
-          setFormData(prev => ({
-            ...prev,
-            phone: prev.phone || userData.phone || '',
-            fullName: prev.fullName || userData.fullName || ''
-          }));
         }
       }
     } catch (error) {
@@ -431,8 +417,8 @@ const initSquareCard = useCallback(async () => {
           photoUrl: item.photoUrl
         })),
         customerInfo: {
-          name: (formData.fullName || currentUser?.full_name || currentUser?.fullName || '').trim(),
-          phone: formData.phone.trim(),
+          name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
+          phone: (currentUser?.phone || '').trim(),
           email: currentUser?.email || ''
         },
         paymentMethod: selectedPaymentMethod as 'card' | 'apple_pay' | 'google_pay',
@@ -492,8 +478,8 @@ const initSquareCard = useCallback(async () => {
           photoUrl: item.photoUrl
         })),
         customerInfo: {
-          name: (formData.fullName || currentUser?.full_name || currentUser?.fullName || '').trim(),
-          phone: formData.phone.trim(),
+          name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
+          phone: (currentUser?.phone || '').trim(),
           email: currentUser?.email || ''
         },
         paymentMethod: 'zelle',
@@ -530,38 +516,6 @@ const initSquareCard = useCallback(async () => {
       ...formData,
       [e.target.name]: e.target.value
     });
-  };
-
-  const saveCustomerInfo = async () => {
-    try {
-      const fullName = formData.fullName.trim();
-      const updatedUser = {
-        ...(currentUser || {}),
-        fullName,
-        full_name: fullName,
-        phone: formData.phone,
-        email: currentUser?.email || ''
-      };
-
-      localStorage.setItem('bakery-user', JSON.stringify(updatedUser));
-
-      if (currentUser?.id) {
-        await supabase
-          .from('profiles')
-          .upsert({
-            id: currentUser.id,
-            full_name: fullName,
-            phone: formData.phone,
-            updated_at: new Date().toISOString()
-          });
-      }
-
-      setCurrentUser(updatedUser);
-      showNotification('success', 'Datos guardados', 'Tu información ha sido guardada');
-    } catch (err) {
-      console.error('Error saving customer info:', err);
-      showNotification('error', 'Error', 'No se pudo guardar tu información');
-    }
   };
 
   // Componente de notificaciones modernas
@@ -1141,44 +1095,6 @@ const initSquareCard = useCallback(async () => {
               </div>
             </div>
           </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Nombre
-            </label>
-            <input
-              type="text"
-              name="fullName"
-              value={formData.fullName}
-              onChange={handleInputChange}
-              required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm"
-              placeholder="Tu nombre"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Número de Teléfono *
-            </label>
-            <input
-              type="tel"
-              name="phone"
-              value={formData.phone}
-              onChange={handleInputChange}
-              required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm"
-              placeholder="(862) 233-7204"
-            />
-          </div>
-
-          <button
-            type="button"
-            onClick={saveCustomerInfo}
-            className="w-full bg-blue-100 text-blue-700 py-2 rounded-lg text-sm mb-4"
-          >
-            Guardar Información
-          </button>
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">


### PR DESCRIPTION
## Summary
- Remove name and phone inputs from the order form and rely on profile data
- Use the authenticated user's stored name and phone when creating orders
- Simplify form state to only track pickup time and special requests

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e9d2bd8c8327bb4f32869a1e1e66