### PR TITLE
feat: cache users list

### DIFF
--- a/app/dashboard/UserManagement.tsx
+++ b/app/dashboard/UserManagement.tsx
@@ -117,6 +117,16 @@ export default function UserManagement() {
 
       if (error) {
         console.error('Error al cargar usuarios:', error);
+        try {
+          const cached = localStorage.getItem('bakery-users');
+          if (cached) {
+            setUsers(JSON.parse(cached));
+            setErrorMessage(null);
+            return;
+          }
+        } catch (storageError) {
+          console.error('Error leyendo usuarios desde cache:', storageError);
+        }
         setErrorMessage('No se pudieron cargar los usuarios. Revisa la consola para más detalles.');
         return;
       }
@@ -135,9 +145,24 @@ export default function UserManagement() {
       }));
 
       setUsers(cleanedUsers);
-      
+      try {
+        localStorage.setItem('bakery-users', JSON.stringify(cleanedUsers));
+      } catch (storageError) {
+        console.error('Error guardando usuarios en cache:', storageError);
+      }
+
     } catch (error) {
       console.error('Error de conexión al cargar usuarios:', error);
+      try {
+        const cached = localStorage.getItem('bakery-users');
+        if (cached) {
+          setUsers(JSON.parse(cached));
+          setErrorMessage(null);
+          return;
+        }
+      } catch (storageError) {
+        console.error('Error leyendo usuarios desde cache:', storageError);
+      }
       setErrorMessage('Error de conexión al cargar usuarios.');
     }
   };


### PR DESCRIPTION
## Summary
- cache user list locally and reuse when Supabase fails

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68c0f3a2a8a4832780b70ecbaca5f25b