### PR TITLE
Require pickup time before payment

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -335,6 +335,11 @@ const initSquareCard = useCallback(async () => {
       return;
     }
 
+    if (!formData.pickupTime) {
+      showNotification('warning', 'Hora de Recogida', 'Por favor selecciona una hora de recogida antes de continuar.');
+      return;
+    }
+
     setShowPayment(true);
   };
 
@@ -1098,6 +1103,7 @@ const initSquareCard = useCallback(async () => {
               name="pickupTime"
               value={formData.pickupTime}
               onChange={handleInputChange}
+              required
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm"
             >
               <option value="">Seleccionar hora de recogida</option>


### PR DESCRIPTION
## Summary
- prevent users from proceeding to payment without selecting a pickup time
- mark pickup time field as required in the order form

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive setup prompt)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f3fa526483278824ac74fc0616ed