### PR TITLE
feat: improve Square payment CVV error messaging

### DIFF
--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -100,7 +100,15 @@ serve(async (req) => {
 
         const data = await resp.json();
         if (!resp.ok) {
-          throw new Error(`Square API Error: ${JSON.stringify(data)}`);
+          console.error('Square API error:', data);
+          const code = data?.errors?.[0]?.code;
+          let message = data?.errors?.[0]?.detail || 'Error al procesar el pago con Square';
+          if (code === 'VERIFY_CVV_FAILURE') {
+            message = 'El código de seguridad (CVV) es incorrecto. Verifica los datos de tu tarjeta.';
+          } else if (code === 'INVALID_CARD_DATA') {
+            message = 'Los datos de la tarjeta son inválidos. Revisa el número, fecha y CVV.';
+          }
+          throw new Error(message);
         }
 
         paymentResult = data.payment;


### PR DESCRIPTION
## Summary
- Map common Square payment errors to friendlier messages
- Log Square API errors before returning descriptive feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: 50 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a2439db08327abd35e7f4b0cc871