### PR TITLE
Disable Apple and Google Pay in checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
-## Square payments with Apple Pay and Google Pay
+## Square payments (solo tarjeta)
 
-The project integrates [Square Web Payments SDK](https://developer.squareup.com/docs/web-payments/overview) to accept cards and digital wallets.
+The project integrates [Square Web Payments SDK](https://developer.squareup.com/docs/web-payments/overview) to accept card payments. Apple Pay y Google Pay están deshabilitados temporalmente.
 
 1. **Environment variables** – create a `.env.local` file based on `.env.example` and set:
    - `NEXT_PUBLIC_SQUARE_APPLICATION_ID`
    - `NEXT_PUBLIC_SQUARE_LOCATION_ID`
    - server-side keys `SQUARE_APPLICATION_ID`, `SQUARE_LOCATION_ID`, and `SQUARE_ACCESS_TOKEN` for the Supabase function.
-2. **Apple Pay domain verification** – Square requires the file `apple-developer-merchantid-domain-association` to be served from `/.well-known/`. The file is included at `public/.well-known/apple-developer-merchantid-domain-association`.
-3. **Enable digital wallets in Square Dashboard** – ensure Apple Pay and Google Pay are enabled for the location.
-4. When the page loads, the app verifies availability via the SDK's `canMakePayment()` and only shows the corresponding buttons if supported by the device and browser.
 
 ## Learn More
 

--- a/lib/squareConfig.ts
+++ b/lib/squareConfig.ts
@@ -18,11 +18,7 @@ export const squareConfig = {
   },
 };
 
-// Default wallet options for Apple Pay and Google Pay
-export const walletOptions = {
-  countryCode: 'US',
-  currencyCode: 'USD',
-};
+// Apple Pay y Google Pay deshabilitados; walletOptions removido
 
 // ---- Supabase Edge Function names ----
 export const EDGE_FUNCTIONS = {
@@ -62,7 +58,7 @@ export const isValidUUID = (value?: string | null): boolean => {
 };
 
 // ---- Types for Square payments ----
-export type SquarePaymentMethod = 'card' | 'apple_pay' | 'google_pay';
+export type SquarePaymentMethod = 'card';
 
 export type SquareOrderItem = {
   name: string;
@@ -80,7 +76,7 @@ export interface SquareOrderData {
   };
   paymentMethod: SquarePaymentMethod;
 
-  // Token returned by Square Web Payments SDK (card / Apple Pay / Google Pay)
+  // Token returned by Square Web Payments SDK (card)
   sourceId?: string;
 
   userId: string;


### PR DESCRIPTION
## Summary
- disable Apple Pay and Google Pay handling in order form
- limit Square configuration to card payments only
- update docs to note wallets are temporarily disabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1af18fc8327a2ffd9ccd1faa450