### PR TITLE
feat: add billing address field to payments

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -59,6 +59,8 @@ useEffect(() => {
     specialRequests: '',
     pickupTime: ''
   });
+  const [billingAddress, setBillingAddress] = useState('');
+  const [saveBillingAddress, setSaveBillingAddress] = useState(true);
 
   const appId = process.env.NEXT_PUBLIC_SQUARE_APPLICATION_ID || '';
   const locationId = process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID || '';
@@ -211,6 +213,11 @@ const initSquareCard = useCallback(async () => {
       });
     }
 
+    const savedBilling = localStorage.getItem('bakery-billing-address');
+    if (savedBilling) {
+      setBillingAddress(savedBilling);
+    }
+
     checkCurrentUser();
   }, []);
 
@@ -349,6 +356,12 @@ const initSquareCard = useCallback(async () => {
     try {
       console.log('🔥 Iniciando proceso de pago:', selectedPaymentMethod);
 
+      if (saveBillingAddress && billingAddress.trim()) {
+        localStorage.setItem('bakery-billing-address', billingAddress.trim());
+      } else {
+        localStorage.removeItem('bakery-billing-address');
+      }
+
       if (selectedPaymentMethod === 'zelle') {
         setP2PInstructions({
           method: 'zelle',
@@ -418,7 +431,8 @@ const initSquareCard = useCallback(async () => {
         customerInfo: {
           name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
           phone: (currentUser?.phone || '').trim(),
-          email: currentUser?.email || ''
+          email: currentUser?.email || '',
+          billingAddress: billingAddress.trim()
         },
         paymentMethod: selectedPaymentMethod as 'card' | 'apple_pay' | 'google_pay',
         sourceId,
@@ -462,6 +476,12 @@ const initSquareCard = useCallback(async () => {
     setIsSubmitting(true);
 
     try {
+      if (saveBillingAddress && billingAddress.trim()) {
+        localStorage.setItem('bakery-billing-address', billingAddress.trim());
+      } else {
+        localStorage.removeItem('bakery-billing-address');
+      }
+
       const { data: { session } } = await supabase.auth.getSession();
       const userId = session?.user?.id;
       if (!userId) {
@@ -479,7 +499,8 @@ const initSquareCard = useCallback(async () => {
         customerInfo: {
           name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
           phone: (currentUser?.phone || '').trim(),
-          email: currentUser?.email || ''
+          email: currentUser?.email || '',
+          billingAddress: billingAddress.trim()
         },
         paymentMethod: 'zelle',
         userId,
@@ -734,10 +755,27 @@ const initSquareCard = useCallback(async () => {
             Los datos de tu tarjeta son procesados de forma segura por Square
           </p>
         </div>
+        <div className="bg-white rounded-xl p-4 mb-6">
+          <h4 className="font-semibold text-gray-800 mb-3">Dirección de Facturación</h4>
+          <textarea
+            className="w-full border rounded-lg p-3"
+            placeholder="Calle, ciudad, código postal"
+            value={billingAddress}
+            onChange={(e) => setBillingAddress(e.target.value)}
+          />
+          <label className="flex items-center mt-2 text-sm text-gray-600">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={saveBillingAddress}
+              onChange={(e) => setSaveBillingAddress(e.target.checked)}
+            />
+            Guardar esta dirección para futuras compras
+          </label>
+        </div>
 
-
-            <div className="bg-gray-50 rounded-xl p-4">
-              <h4 className="font-semibold text-gray-800 mb-3">Resumen del Pago</h4>
+        <div className="bg-gray-50 rounded-xl p-4">
+          <h4 className="font-semibold text-gray-800 mb-3">Resumen del Pago</h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-gray-600">Subtotal:</span>

--- a/lib/squareConfig.ts
+++ b/lib/squareConfig.ts
@@ -77,6 +77,7 @@ export interface SquareOrderData {
     name: string;
     phone: string;
     email?: string;
+    billingAddress?: string;
   };
   paymentMethod: SquarePaymentMethod;
 
@@ -154,7 +155,7 @@ export async function createSquarePayment(orderData: SquareOrderData) {
 export async function createP2POrder(orderData: {
   amount: number; // dollars
   items: SquareOrderItem[];
-  customerInfo: { name: string; phone: string; email?: string };
+  customerInfo: { name: string; phone: string; email?: string; billingAddress?: string };
   paymentMethod: 'zelle';
   userId: string;
   pickupTime?: string;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -30,6 +30,7 @@ export interface Order {
   customer_name: string
   customer_phone: string
   customer_email?: string
+  billing_address?: string
   items: any[]
   subtotal: number
   tax: number

--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -80,6 +80,7 @@ serve(async (req) => {
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
+        billing_address: orderData.customerInfo?.billingAddress?.trim() || null,
         items: orderData.items || [],
         subtotal,
         tax,

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -144,6 +144,7 @@ serve(async (req) => {
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || null,
         customer_email: orderData.customerInfo?.email?.trim() || null,
+        billing_address: orderData.customerInfo?.billingAddress?.trim() || null,
         items: orderData.items,
         subtotal: +(orderData.amount - orderData.amount * 0.03).toFixed(2),
         tax: +(orderData.amount * 0.03).toFixed(2),

--- a/supabase/migrations/20250115120000_add_billing_address_to_orders.sql
+++ b/supabase/migrations/20250115120000_add_billing_address_to_orders.sql
@@ -1,0 +1,2 @@
+-- Add billing_address column to store customer billing addresses
+alter table orders add column if not exists billing_address text;


### PR DESCRIPTION
## Summary
- collect billing address during card payments and allow saving for future orders
- forward billing address through payment APIs and store with orders
- add billing_address column to orders table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next.js ESLint prompt)*
- `npm run build` *(fails: Export encountered errors on several paths)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a51915848327999b8c73e68078ec