### PR TITLE
Fix user dashboard by fetching profiles via API

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: 'Missing Supabase configuration' }, { status: 500 });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+  const { data, error } = await supabaseAdmin
+    .from('profiles')
+    .select('id, email, full_name, phone, role, created_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data });
+}
+
+export async function PUT(request: Request) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: 'Missing Supabase configuration' }, { status: 500 });
+  }
+
+  const { userId, newRole } = await request.json();
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+  const { error } = await supabaseAdmin
+    .from('profiles')
+    .update({ role: newRole, updated_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add server API route to fetch and update profiles
- use the API in dashboard user management

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive setup)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad4eb98083279513d427bad21fd6