### PR TITLE
Use Supabase roles for routing

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -22,10 +22,6 @@ export default function AuthPage() {
   const router = useRouter();
   const { t } = useLanguage();
 
-  const ownerEmails = [
-    'yskmem@pm.me','yeskoldj@gmail.com','rangerbakery@gmail.com',
-  ];
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -76,9 +72,9 @@ export default function AuthPage() {
             console.warn('⚠️ Error al obtener perfil (puede ser normal):', profileError);
           }
 
-          // Determinar rol y permisos
-          const isOwner = ownerEmails.includes(normalizedEmail);
-          const userRole = profile?.role || (isOwner ? 'owner' : 'customer');
+          // Determinar rol y permisos desde el servidor
+          const userRole = profile?.role || 'customer';
+          const isOwner = userRole === 'owner';
 
           const userData = {
             id: data.user.id,
@@ -95,7 +91,7 @@ export default function AuthPage() {
           console.log('👤 Usuario autenticado:', userData);
 
           // Redirigir según el rol
-          if (isOwner || userRole === 'owner' || userRole === 'employee') {
+          if (userRole === 'owner' || userRole === 'employee') {
             router.push('/dashboard');
           } else {
             router.push('/');
@@ -159,10 +155,10 @@ export default function AuthPage() {
         if (data.user) {
           console.log('✅ Registro exitoso para usuario:', data.user.id);
           
-          // Determinar rol automáticamente
-          const isOwner = ownerEmails.includes(normalizedEmail);
-          const userRole = isOwner ? 'owner' : 'customer';
-          
+          // Asignar rol por defecto para nuevos usuarios
+          const userRole = 'customer';
+          const isOwner = false;
+
           // Crear perfil en la tabla profiles
           const { error: profileError } = await supabase
             .from('profiles')

--- a/app/dashboard/UserManagement.tsx
+++ b/app/dashboard/UserManagement.tsx
@@ -47,8 +47,8 @@ export default function UserManagement() {
       const localUser = localStorage.getItem('bakery-user');
       if (localUser) {
         const userData = JSON.parse(localUser);
-        setCurrentUser({ 
-          role: userData.isOwner ? 'owner' : 'customer',
+        setCurrentUser({
+          role: userData.role || (userData.isOwner ? 'owner' : 'customer'),
           email: userData.email,
           full_name: userData.fullName || userData.email.split('@')[0],
           phone: userData.phone || ''
@@ -61,7 +61,7 @@ export default function UserManagement() {
           confirmPassword: ''
         });
         
-        if (userData.isOwner || userData.email === 'yskmem@pm.me') {
+        if (userData.role === 'owner' || userData.role === 'employee') {
           await loadUsersFromDatabase();
         }
         setLoading(false);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -100,13 +100,13 @@ export default function DashboardPage() {
       }
 
       const user_data = JSON.parse(userData);
-      if (!user_data.isOwner) {
+      if (!['owner', 'employee'].includes(user_data.role)) {
         router.push('/');
         return;
       }
 
       setCurrentUser({
-        role: 'owner',
+        role: user_data.role,
         email: user_data.email,
         full_name: user_data.fullName || user_data.email.split('@')[0],
       });
@@ -117,9 +117,9 @@ export default function DashboardPage() {
       const userData = localStorage.getItem('bakery-user');
       if (userData) {
         const user_data = JSON.parse(userData);
-        if (user_data.isOwner) {
+        if (['owner', 'employee'].includes(user_data.role)) {
           setCurrentUser({
-            role: 'owner',
+            role: user_data.role,
             email: user_data.email,
             full_name: user_data.fullName || user_data.email.split('@')[0],
           });

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -69,7 +69,7 @@ export default function ProfilePage() {
         email: userData.email,
         full_name: userData.fullName || userData.email.split('@')[0],
         phone: userData.phone || '',
-        role: userData.isOwner ? 'owner' : 'customer'
+        role: userData.role || (userData.isOwner ? 'owner' : 'customer')
       });
 
       setProfileData({
@@ -88,7 +88,7 @@ export default function ProfilePage() {
           email: userData.email,
           full_name: userData.fullName || userData.email.split('@')[0],
           phone: userData.phone || '',
-          role: userData.isOwner ? 'owner' : 'customer'
+          role: userData.role || (userData.isOwner ? 'owner' : 'customer')
         });
 
         setProfileData({

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -66,7 +66,7 @@ export default function Header() {
       setCurrentUser({
         email: user.email,
         full_name: user.fullName || user.email.split('@')[0],
-        role: user.isOwner ? 'owner' : 'customer',
+        role: user.role || (user.isOwner ? 'owner' : 'customer'),
         isLocal: true
       });
     } else {


### PR DESCRIPTION
## Summary
- remove hardcoded ownerEmails and determine role from Supabase profile
- store and use user role for dashboard and profile routing
- base dashboard and user management access on role instead of email

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c1b5b8b8608327b47d132be1c02079