### PR TITLE
Fix payment status logic and metadata configuration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { LanguageProvider } from "../lib/languageContext";
 import "./globals.css";
 
@@ -7,8 +7,14 @@ export const metadata: Metadata = {
   title: "Ranger's Bakery - Repostería Dominicana",
   description: "Deliciosos pasteles y postres dominicanos hechos con amor para tus momentos especiales",
   manifest: "/manifest.json",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
   themeColor: "#f472b6",
-  viewport: "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no",
 };
 
 export default function RootLayout({

--- a/app/quote/page.tsx
+++ b/app/quote/page.tsx
@@ -266,7 +266,7 @@ export default function QuotePage() {
       // Preparar datos para Supabase
       const quoteRecord = {
         customer_name: quoteData.contactInfo.name.trim(),
-        customer_phone: quoteData.contactInfo.phone.trim() || null,
+        customer_phone: quoteData.contactInfo.phone.trim() || '',
         customer_email: quoteData.contactInfo.email.trim() || null,
         occasion: quoteData.occasion || null,
         age_group: quoteData.ageGroup || null,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -87,7 +87,7 @@ serve(async (req) => {
         user_id: profile.id,
         // Provide default name to satisfy NOT NULL constraint in the DB
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
-        customer_phone: orderData.customerInfo?.phone?.trim() || null,
+        customer_phone: orderData.customerInfo?.phone?.trim() || '',
         customer_email: orderData.customerInfo?.email?.trim() || null,
         billing_address: orderData.customerInfo?.billingAddress?.trim() || null,
         items: orderData.items || [],
@@ -105,7 +105,7 @@ serve(async (req) => {
         status: 'pending',
         order_date: new Date().toISOString().split('T')[0],
         payment_type: orderData.paymentMethod,
-        payment_status: 'completed',
+        payment_status: 'pending',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       }

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -152,7 +152,7 @@ serve(async (req) => {
         user_id: profile.id,
         // Ensure a non-null customer_name to satisfy DB constraints
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
-        customer_phone: orderData.customerInfo?.phone?.trim() || null,
+        customer_phone: orderData.customerInfo?.phone?.trim() || '',
         customer_email: orderData.customerInfo?.email?.trim() || null,
         billing_address: orderData.customerInfo?.billingAddress?.trim() || null,
         items: orderData.items,


### PR DESCRIPTION
## Summary
- use eslint directly and drop empty pages dir
- ensure customer phones default to string and P2P orders start as pending
- move theme color and viewport to Next.js viewport export

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="test" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1cf1112648327b21ed7e9e130a8cd