### PR TITLE
Fix revenue rounding on dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -664,7 +664,7 @@ export default function DashboardPage() {
             <div className="bg-white rounded-lg p-3 text-center shadow-sm">
               <p className="text-xs text-gray-600">Ingresos</p>
               <p className="text-lg font-bold text-blue-600">
-                ${getTotalRevenue().toFixed(0)}
+                ${getTotalRevenue().toFixed(2)}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- display total revenue with cents instead of rounding to whole dollars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 29 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d82686f48327baf9b1adcdd7a544