### PR TITLE
Add sitemap for Google indexing

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://example.com';
+
+  return [
+    { url: baseUrl, lastModified: new Date() },
+    { url: `${baseUrl}/cart`, lastModified: new Date() },
+    { url: `${baseUrl}/quote`, lastModified: new Date() },
+    { url: `${baseUrl}/auth`, lastModified: new Date() },
+    { url: `${baseUrl}/menu`, lastModified: new Date() },
+    { url: `${baseUrl}/profile`, lastModified: new Date() },
+    { url: `${baseUrl}/prices`, lastModified: new Date() },
+    { url: `${baseUrl}/dashboard`, lastModified: new Date() },
+    { url: `${baseUrl}/cakes`, lastModified: new Date() },
+    { url: `${baseUrl}/track`, lastModified: new Date() },
+    { url: `${baseUrl}/order`, lastModified: new Date() },
+  ];
+}
+


### PR DESCRIPTION
## Summary
- add sitemap generation for search engines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 28 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e2d0872c8327a50ce99259bcd070