### PR TITLE
Add install prompt and favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 
 import type { Metadata, Viewport } from "next";
 import { LanguageProvider } from "../lib/languageContext";
+import InstallPrompt from "../components/InstallPrompt";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -32,14 +33,15 @@ export default function RootLayout({
           rel="stylesheet" 
         />
         <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" href="/icon.svg" type="image/svg+xml" />
         <meta name="theme-color" content="#f472b6" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Ranger's Bakery" />
-        <link rel="apple-touch-icon" href="/icon-192x192.png" />
       </head>
       <body className="font-sans antialiased">
         <LanguageProvider>
+          <InstallPrompt />
           {children}
         </LanguageProvider>
       </body>

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function InstallPrompt() {
+  const [promptEvent, setPromptEvent] = useState<any>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {
+        // ignore registration errors
+      });
+    }
+
+    const handler = (e: any) => {
+      e.preventDefault();
+      setPromptEvent(e);
+      setShow(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const onInstall = async () => {
+    if (!promptEvent) return;
+    promptEvent.prompt();
+    await promptEvent.userChoice;
+    setShow(false);
+    setPromptEvent(null);
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed bottom-4 left-0 right-0 flex justify-center">
+      <button
+        onClick={onInstall}
+        className="bg-pink-500 text-white px-4 py-2 rounded shadow"
+      >
+        Instalar aplicación
+      </button>
+    </div>
+  );
+}

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <circle cx="256" cy="256" r="240" fill="white" stroke="#6b2d1f" stroke-width="32"/>
+  <text x="50%" y="55%" text-anchor="middle" font-family="Arial, sans-serif" font-size="160" fill="#6b2d1f">RB</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ranger's Bakery",
+  "short_name": "Ranger's Bakery",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#f472b6",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,4 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
## Summary
- add basic PWA manifest and service worker
- show install banner when app is installable
- use simple SVG favicon based on bakery logo

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 28 errors, 19 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c1e435fe888327b7926cb3095d7f94