### PR TITLE
Implement cake quote flow and surface customization details

### DIFF
--- a/app/cakes/[id]/CakeCustomizer.tsx
+++ b/app/cakes/[id]/CakeCustomizer.tsx
@@ -631,6 +631,22 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
       .filter(Boolean)
       .join(', ');
 
+    const summaryParts = [
+      selectedOptions.shape ? `Forma: ${shapeOptions.find(s => s.id === selectedOptions.shape)?.name}` : null,
+      layerDescriptions ? `Capas: ${layerDescriptions}` : null,
+      flavorNames ? `Sabores: ${flavorNames}` : null,
+      selectedOptions.colors.length ? `Colores: ${selectedOptions.colors.map(id => colorOptions.find(c => c.id === id)?.name).filter(Boolean).join(', ')}` : null,
+      customizerMode === 'advanced' && selectedOptions.fillings.length
+        ? `Rellenos: ${selectedOptions.fillings.map(id => fillingOptions.find(f => f.id === id)?.name).filter(Boolean).join(', ')}`
+        : null,
+      customizerMode === 'advanced' && decorationNames ? `Decoraciones: ${decorationNames}` : null,
+      selectedOptions.inscription ? `Mensaje: ${selectedOptions.inscription}` : null,
+      selectedOptions.specialRequests ? `Notas: ${selectedOptions.specialRequests}` : null,
+      selectedOptions.photoUrl ? 'Incluye foto de referencia' : null
+    ].filter(Boolean);
+
+    const customizationSummary = summaryParts.join('\n');
+
     const cartItem = {
       id: `cake-${Date.now()}`,
       name: `${currentProduct?.name} Personalizado`,
@@ -638,6 +654,7 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
       quantity: quantity,
       image: currentProduct?.image || '',
       photoUrl: selectedOptions.photoUrl || undefined,
+      details: customizationSummary,
       type: 'cake',
       customization: {
         mode: customizerMode,
@@ -655,7 +672,8 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
         decorations: customizerMode === 'advanced' ? decorationNames : '',
         inscription: selectedOptions.inscription,
         specialRequests: selectedOptions.specialRequests,
-        photoUrl: selectedOptions.photoUrl || undefined
+        photoUrl: selectedOptions.photoUrl || undefined,
+        summary: customizationSummary
       }
     };
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -33,6 +33,11 @@ interface Quote {
   admin_notes?: string | null;
   responded_at?: string | null;
   updated_at?: string | null;
+  cart_items?: any[];
+  requires_cake_quote?: boolean;
+  pickup_time?: string | null;
+  special_requests?: string | null;
+  reference_code?: string | null;
 }
 
 const quoteStatusColors: Record<QuoteStatus, string> = {
@@ -358,13 +363,15 @@ export default function DashboardPage() {
         customer_name: quote.customer_name,
         customer_phone: quote.customer_phone || '',
         customer_email: quote.customer_email || '',
-        items: [],
+        items: quote.cart_items || [],
         subtotal: quote.estimated_price || 0,
         tax: 0,
         total: quote.estimated_price || 0,
         status: 'pending',
         payment_status: 'pending',
         order_date: now,
+        pickup_time: quote.pickup_time || null,
+        special_requests: quote.special_requests || quote.event_details || null,
         created_at: now,
         updated_at: now,
       } as any;
@@ -1218,6 +1225,45 @@ function QuoteCard({ quote, onStatusUpdate, onFinalize, onDelete }: { quote: Quo
         <div className="mb-4 p-3 bg-amber-50 rounded-lg border-l-4 border-amber-400">
           <p className="text-sm font-medium text-amber-800 mb-1">Detalles del Evento:</p>
           <p className="text-sm text-amber-700">{quote.event_details}</p>
+        </div>
+      )}
+
+      {quote.requires_cake_quote && (
+        <div className="mb-4 p-3 bg-pink-50 rounded-lg border-l-4 border-pink-400">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-semibold text-pink-800">Personalización del pastel</p>
+            {quote.reference_code && (
+              <span className="text-xs font-medium text-pink-600">Ref: {quote.reference_code}</span>
+            )}
+          </div>
+          <div className="space-y-2">
+            {(quote.cart_items || []).map((item, index) => (
+              <div key={`${quote.id}-item-${index}`} className="bg-white rounded-md p-2 shadow-sm border border-pink-100">
+                <p className="text-sm font-semibold text-gray-800">
+                  {item.quantity || 1}x {item.name}
+                </p>
+                {item.details && (
+                  <p className="text-xs text-gray-600 whitespace-pre-line mt-1">{item.details}</p>
+                )}
+                {!item.details && item.customization && (
+                  <p className="text-xs text-gray-600 mt-1">
+                    {Object.entries(item.customization)
+                      .filter(([key, value]) => value && typeof value === 'string')
+                      .map(([key, value]) => `${key}: ${value}`)
+                      .join(' | ')}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+          {quote.pickup_time && (
+            <p className="text-xs text-pink-700 mt-2">
+              Hora preferida de recogida: <span className="font-semibold">{quote.pickup_time}</span>
+            </p>
+          )}
+          {quote.special_requests && (
+            <p className="text-xs text-pink-700 mt-1 whitespace-pre-line">Notas: {quote.special_requests}</p>
+          )}
         </div>
       )}
 

--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabase';
+import { supabase, Order } from '@/lib/supabase';
 import { squareConfig } from '@/lib/square/config';
 import { createSquarePayment } from '@/lib/square/payments';
 import { createP2POrder, p2pPaymentConfig } from '@/lib/square/p2p';
@@ -16,6 +16,8 @@ interface CartItem {
   quantity: number;
   image?: string;
   photoUrl?: string;
+  type?: string;
+  details?: string;
   customization?: any;
 }
 
@@ -26,10 +28,16 @@ interface Notification {
   message: string;
 }
 
-export default function OrderForm() {
+interface OrderFormProps {
+  orderId?: string;
+}
+
+export default function OrderForm({ orderId }: OrderFormProps) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
+  const [quoteSubmitted, setQuoteSubmitted] = useState(false);
+  const [quoteReference, setQuoteReference] = useState<string | null>(null);
   const [showPayment, setShowPayment] = useState(false);
   const [showCardForm, setShowCardForm] = useState(false);
 
@@ -55,6 +63,7 @@ useEffect(() => {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<'card' | 'zelle'>('card');
   const [p2pInstructions, setP2PInstructions] = useState<any>(null);
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
+  const [existingOrder, setExistingOrder] = useState<Order | null>(null);
   const [currentUser, setCurrentUser] = useState<any>(null);
   const [addedItems, setAddedItems] = useState<Set<string>>(new Set());
   const [notifications, setNotifications] = useState<Notification[]>([]);
@@ -70,6 +79,115 @@ useEffect(() => {
     .filter(Boolean)
     .join(', ');
   const [saveBillingAddress, setSaveBillingAddress] = useState(true);
+
+  const showNotification = useCallback(
+    (type: 'success' | 'error' | 'warning' | 'info', title: string, message: string) => {
+      const id = Date.now().toString();
+      const notification: Notification = { id, type, title, message };
+
+      setNotifications(prev => [...prev, notification]);
+
+      setTimeout(() => {
+        setNotifications(prev => prev.filter(n => n.id !== id));
+      }, 5000);
+    },
+    []
+  );
+
+  const dismissNotification = useCallback((id: string) => {
+    setNotifications(prev => prev.filter(n => n.id !== id));
+  }, []);
+
+  const loadExistingOrder = useCallback(
+    async (id: string) => {
+      try {
+        const { data, error } = await supabase
+          .from('orders')
+          .select('*')
+          .eq('id', id)
+          .single();
+
+        if (error || !data) {
+          throw new Error(error?.message || 'Order not found');
+        }
+
+        const normalizedItems: CartItem[] = Array.isArray(data.items)
+          ? data.items.map((item: any, index: number) => {
+              const rawPrice = item?.price ?? 0;
+              const numericPrice = typeof rawPrice === 'number'
+                ? rawPrice
+                : parseFloat(String(rawPrice).replace(/[^0-9.,]/g, '').replace(',', '.')) || 0;
+
+              return {
+                id: item?.id || `${id}-${index}`,
+                name: item?.name || `Producto ${index + 1}`,
+                price: numericPrice,
+                quantity: item?.quantity ?? 1,
+                image: item?.image,
+                photoUrl: item?.photoUrl,
+                details: item?.details || item?.customization?.summary || '',
+                customization: item?.customization,
+                type: item?.type,
+              };
+            })
+          : [];
+
+        setExistingOrder(data as Order);
+        setCartItems(normalizedItems);
+        setFormData({
+          specialRequests: data.special_requests || '',
+          pickupTime: data.pickup_time || '',
+        });
+      } catch (err: any) {
+        console.error('Error loading existing order:', err);
+        showNotification(
+          'error',
+          'Orden no disponible',
+          'No pudimos cargar tu orden. Por favor verifica el enlace o contacta a la panadería.'
+        );
+      }
+    },
+    [showNotification]
+  );
+
+  const getCustomizationDetails = (item: CartItem): string => {
+    if (item.details && String(item.details).trim().length > 0) {
+      return item.details;
+    }
+
+    const customization = item.customization || {};
+    const details: string[] = [];
+
+    if (customization.shape) {
+      details.push(`Forma: ${customization.shape}`);
+    }
+    if (customization.layers) {
+      details.push(`Niveles: ${customization.layers}`);
+    }
+    if (customization.flavors) {
+      details.push(`Sabores: ${customization.flavors}`);
+    }
+    if (customization.colors) {
+      details.push(`Colores: ${customization.colors}`);
+    }
+    if (customization.fillings) {
+      details.push(`Rellenos: ${customization.fillings}`);
+    }
+    if (customization.decorations) {
+      details.push(`Decoraciones: ${customization.decorations}`);
+    }
+    if (customization.inscription) {
+      details.push(`Mensaje: ${customization.inscription}`);
+    }
+    if (customization.specialRequests) {
+      details.push(`Notas: ${customization.specialRequests}`);
+    }
+    if (customization.photoUrl) {
+      details.push('Incluye foto de referencia');
+    }
+
+    return details.join(' | ');
+  };
 
   const appId = process.env.NEXT_PUBLIC_SQUARE_APPLICATION_ID || '';
   const locationId = process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID || '';
@@ -164,37 +282,31 @@ const initSquareCard = useCallback(async () => {
     }
   }, [showCardForm, card, initSquareCard]);
 
-  // Función para mostrar notificaciones modernas
-  const showNotification = (type: 'success' | 'error' | 'warning' | 'info', title: string, message: string) => {
-    const id = Date.now().toString();
-    const notification: Notification = { id, type, title, message };
-    
-    setNotifications(prev => [...prev, notification]);
-    
-    // Auto-remove después de 5 segundos
-    setTimeout(() => {
-      setNotifications(prev => prev.filter(n => n.id !== id));
-    }, 5000);
-  };
-
-  // Función para cerrar notificación manualmente
-  const dismissNotification = (id: string) => {
-    setNotifications(prev => prev.filter(n => n.id !== id));
-  };
-
   useEffect(() => {
-    const savedCart = localStorage.getItem('bakery-cart');
-    if (savedCart) {
-      setCartItems(JSON.parse(savedCart));
-    }
+    if (orderId) {
+      loadExistingOrder(orderId);
+    } else {
+      const savedCart = localStorage.getItem('bakery-cart');
+      if (savedCart) {
+        try {
+          setCartItems(JSON.parse(savedCart));
+        } catch {
+          setCartItems([]);
+        }
+      }
 
-    const savedForm = localStorage.getItem('bakery-order-form');
-    if (savedForm) {
-      const parsed = JSON.parse(savedForm);
-      setFormData({
-        specialRequests: parsed.specialRequests || '',
-        pickupTime: parsed.pickupTime || ''
-      });
+      const savedForm = localStorage.getItem('bakery-order-form');
+      if (savedForm) {
+        try {
+          const parsed = JSON.parse(savedForm);
+          setFormData({
+            specialRequests: parsed.specialRequests || '',
+            pickupTime: parsed.pickupTime || ''
+          });
+        } catch {
+          setFormData({ specialRequests: '', pickupTime: '' });
+        }
+      }
     }
 
     const savedBilling = localStorage.getItem('bakery-billing-address');
@@ -213,7 +325,7 @@ const initSquareCard = useCallback(async () => {
     }
 
     checkCurrentUser();
-  }, []);
+  }, [orderId, loadExistingOrder]);
 
   useEffect(() => {
     localStorage.setItem('bakery-order-form', JSON.stringify(formData));
@@ -245,12 +357,25 @@ const initSquareCard = useCallback(async () => {
   };
 
   const addToCart = (item: CartItem) => {
+    if (existingOrder) {
+      showNotification(
+        'warning',
+        'Orden bloqueada',
+        'Esta orden ya fue creada. Si necesitas cambios, contacta a la panadería.'
+      );
+      return;
+    }
+
     const cartItem = {
       id: `${item.name.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`,
       name: item.name,
       price: item.price,
       quantity: 1,
-      image: item.image
+      image: item.image,
+      photoUrl: item.photoUrl,
+      details: item.details || getCustomizationDetails(item),
+      customization: item.customization,
+      type: item.type,
     };
 
     const existingCart = localStorage.getItem('bakery-cart');
@@ -282,6 +407,15 @@ const initSquareCard = useCallback(async () => {
   };
 
   const removeFromCart = (id: string, name: string) => {
+    if (existingOrder) {
+      showNotification(
+        'warning',
+        'Orden bloqueada',
+        'Esta orden ya fue creada. Si necesitas cambios, contacta a la panadería.'
+      );
+      return;
+    }
+
     const existingCart = localStorage.getItem('bakery-cart');
     let cart = existingCart ? JSON.parse(existingCart) : [];
     cart = cart.filter((cartItem: any) => cartItem.id !== id);
@@ -315,18 +449,162 @@ const initSquareCard = useCallback(async () => {
   };
 
   const calculateSubtotal = () => {
+    if (existingOrder) {
+      return existingOrder.subtotal ?? 0;
+    }
+
     return cartItems.reduce((total, item) => {
       const price = getItemPrice(item);
-      return total + (price * item.quantity);
+      return total + price * item.quantity;
     }, 0);
   };
 
   const calculateTax = () => {
+    if (existingOrder) {
+      return existingOrder.tax ?? 0;
+    }
+
     return selectedPaymentMethod === 'zelle' ? 0 : calculateSubtotal() * 0.03;
   };
 
+  const calculateTotalValue = () => {
+    return calculateSubtotal() + calculateTax();
+  };
+
   const calculateTotal = () => {
-    return (calculateSubtotal() + calculateTax()).toFixed(2);
+    return calculateTotalValue().toFixed(2);
+  };
+
+  const submitCakeQuote = async () => {
+    const cakeItems = cartItems.filter(
+      (item) => (item.type === 'cake' || item.customization) && !existingOrder
+    );
+
+    if (cakeItems.length === 0) {
+      showNotification('error', 'Sin pasteles personalizados', 'No se detectaron pasteles personalizados en tu carrito.');
+      return;
+    }
+
+    const customerName = (currentUser?.full_name || currentUser?.fullName || '').trim() || 'Cliente';
+    const customerEmail = (currentUser?.email || currentUser?.emailAddress || '').trim();
+    const customerPhone = (currentUser?.phone || '').trim();
+
+    if (!customerEmail && !customerPhone) {
+      showNotification(
+        'warning',
+        'Información de contacto requerida',
+        'Por favor, actualiza tu perfil con un email o teléfono para que podamos contactarte sobre tu cotización.'
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const formattedItems = cartItems.map((item) => ({
+        name: item.name,
+        quantity: item.quantity,
+        price: getItemPrice(item),
+        details: getCustomizationDetails(item),
+        customization: item.customization || null,
+        type: item.type || null,
+        photoUrl: item.photoUrl || null,
+      }));
+
+      const cakeSummaries = cakeItems.map((item, index) => {
+        const detail = getCustomizationDetails(item);
+        return `Pastel ${index + 1}: ${item.name}${detail ? `\n${detail}` : ''}`;
+      });
+
+      const pickupLine = formData.pickupTime
+        ? `\nHora preferida de recogida: ${formData.pickupTime}`
+        : '';
+      const specialLine = formData.specialRequests.trim()
+        ? `\nSolicitudes especiales: ${formData.specialRequests.trim()}`
+        : '';
+
+      const summary = `Resumen de personalización:\n${cakeSummaries.join('\n\n')}${pickupLine}${specialLine}`;
+      const referenceCode = `CAKE-${Date.now()}`;
+
+      const { data, error } = await supabase
+        .from('quotes')
+        .insert([
+          {
+            customer_name: customerName,
+            customer_phone: customerPhone || '',
+            customer_email: customerEmail || null,
+            occasion: 'custom-cake',
+            event_details: summary,
+            status: 'pending',
+            created_at: new Date().toISOString(),
+            cart_items: formattedItems,
+            requires_cake_quote: true,
+            pickup_time: formData.pickupTime || null,
+            special_requests: formData.specialRequests.trim() || null,
+            reference_code: referenceCode,
+          },
+        ])
+        .select()
+        .single();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      const insertedQuote = data || {};
+      const finalReference = insertedQuote.reference_code || referenceCode;
+
+      try {
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+        if (supabaseUrl) {
+          await fetch(`${supabaseUrl}/functions/v1/send-notification-email`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
+            },
+            body: JSON.stringify({
+              to: 'rangerbakery@gmail.com',
+              type: 'new_quote',
+              language: 'es',
+              quoteData: {
+                ...insertedQuote,
+                cart_items: formattedItems,
+                reference_code: finalReference,
+              },
+            }),
+          });
+        }
+      } catch (notificationError) {
+        console.log('Error enviando notificación de cotización:', notificationError);
+      }
+
+      localStorage.removeItem('bakery-cart');
+      localStorage.removeItem('bakery-order-form');
+
+      setQuoteSubmitted(true);
+      setQuoteReference(finalReference);
+      setCartItems([]);
+      setFormData({ specialRequests: '', pickupTime: '' });
+      setShowPayment(false);
+      setShowCardForm(false);
+      setShowP2PInstructions(false);
+
+      showNotification(
+        'success',
+        'Cotización enviada',
+        'Tu solicitud fue enviada al propietario. Te contactaremos con el precio final pronto.'
+      );
+    } catch (err: any) {
+      console.error('Error enviando cotización de pastel:', err);
+      showNotification(
+        'error',
+        'Error al enviar la cotización',
+        err?.message || 'Ocurrió un error al enviar la cotización. Intenta nuevamente.'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -338,6 +616,17 @@ const initSquareCard = useCallback(async () => {
 
     if (!formData.pickupTime) {
       showNotification('warning', 'Hora de Recogida', 'Por favor selecciona una hora de recogida antes de continuar.');
+      return;
+    }
+
+    if (existingOrder) {
+      setShowPayment(true);
+      return;
+    }
+
+    const containsCake = cartItems.some((item) => item.type === 'cake' || item.customization);
+    if (containsCake) {
+      await submitCakeQuote();
       return;
     }
 
@@ -369,9 +658,10 @@ const initSquareCard = useCallback(async () => {
       }
 
       if (selectedPaymentMethod === 'zelle') {
+        const totalAmount = Number(calculateTotalValue().toFixed(2));
         setP2PInstructions({
           method: 'zelle',
-          amount: parseFloat(calculateTotal()),
+          amount: totalAmount,
           email: p2pPaymentConfig.zelle.email,
           name: p2pPaymentConfig.zelle.name,
           instructions: p2pPaymentConfig.zelle.instructions,
@@ -407,26 +697,36 @@ const initSquareCard = useCallback(async () => {
       }
 
       // Crear pago con Square usando el token
+      const subtotal = Number(calculateSubtotal().toFixed(2));
+      const tax = Number(calculateTax().toFixed(2));
+      const total = Number(calculateTotalValue().toFixed(2));
+
       const paymentResult = await createSquarePayment({
-        amount: parseFloat(calculateTotal()),
+        amount: total,
+        subtotal,
+        tax,
         items: cartItems.map(item => ({
           name: item.name,
           price: getItemPrice(item),
           quantity: item.quantity,
-          photoUrl: item.photoUrl
+          photoUrl: item.photoUrl,
+          details: getCustomizationDetails(item),
+          type: item.type,
+          customization: item.customization,
         })),
         customerInfo: {
           name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
           phone: (currentUser?.phone || '').trim(),
           email: currentUser?.email || '',
-          billingAddress
+          billingAddress,
         },
         paymentMethod: 'card',
         sourceId,
         currency: 'USD',
         userId,
-        pickupTime: formData.pickupTime || undefined,
-        specialRequests: formData.specialRequests?.trim() || undefined
+        pickupTime: (existingOrder?.pickup_time || formData.pickupTime) || undefined,
+        specialRequests: (existingOrder?.special_requests || formData.specialRequests)?.trim() || undefined,
+        orderId: existingOrder?.id,
       });
 
       if (paymentResult.success) {
@@ -439,10 +739,30 @@ const initSquareCard = useCallback(async () => {
         setShowPayment(false);
         setShowCardForm(false);
 
+        if (existingOrder) {
+          setExistingOrder({
+            ...existingOrder,
+            payment_status: 'completed',
+            payment_type: 'card',
+            subtotal,
+            tax,
+            total,
+            items: cartItems.map(item => ({
+              name: item.name,
+              quantity: item.quantity,
+              price: getItemPrice(item),
+              photoUrl: item.photoUrl,
+              details: getCustomizationDetails(item),
+              customization: item.customization,
+              type: item.type,
+            })),
+          } as Order);
+        }
+
         // Redirigir al dashboard
         setTimeout(() => {
           setShowSuccess(false);
-          router.push('/dashboard');
+          router.push(existingOrder ? '/track' : '/dashboard');
         }, 3000);
       }
 
@@ -488,23 +808,27 @@ const initSquareCard = useCallback(async () => {
       }
 
       const result = await createP2POrder({
-        amount: calculateSubtotal(),
+        amount: existingOrder ? existingOrder.total ?? calculateSubtotal() : calculateSubtotal(),
         items: cartItems.map(item => ({
           name: item.name,
           price: getItemPrice(item),
           quantity: item.quantity,
-          photoUrl: item.photoUrl
+          photoUrl: item.photoUrl,
+          details: getCustomizationDetails(item),
+          type: item.type,
+          customization: item.customization,
         })),
         customerInfo: {
           name: (currentUser?.full_name || currentUser?.fullName || '').trim(),
           phone: (currentUser?.phone || '').trim(),
           email: currentUser?.email || '',
-          billingAddress
+          billingAddress,
         },
         paymentMethod: 'zelle',
         userId,
-        pickupTime: formData.pickupTime || undefined,
-        specialRequests: formData.specialRequests?.trim() || undefined
+        pickupTime: (existingOrder?.pickup_time || formData.pickupTime) || undefined,
+        specialRequests: (existingOrder?.special_requests || formData.specialRequests)?.trim() || undefined,
+        orderId: existingOrder?.id,
       });
 
       if (!result || !result.success) {
@@ -518,9 +842,26 @@ const initSquareCard = useCallback(async () => {
       setShowSuccess(true);
       setShowP2PInstructions(false);
 
+      if (existingOrder) {
+        setExistingOrder({
+          ...existingOrder,
+          payment_status: 'pending',
+          payment_type: 'zelle',
+          items: cartItems.map(item => ({
+            name: item.name,
+            quantity: item.quantity,
+            price: getItemPrice(item),
+            photoUrl: item.photoUrl,
+            details: getCustomizationDetails(item),
+            customization: item.customization,
+            type: item.type,
+          })),
+        } as Order);
+      }
+
       setTimeout(() => {
         setShowSuccess(false);
-        router.push('/dashboard');
+        router.push(existingOrder ? '/track' : '/dashboard');
       }, 3000);
     } catch (err: any) {
       console.error('❌ Error confirmando pago P2P:', err);
@@ -531,6 +872,15 @@ const initSquareCard = useCallback(async () => {
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    if (existingOrder) {
+      showNotification(
+        'warning',
+        'Pedido en revisión',
+        'Si necesitas cambiar la hora o notas, contacta directamente a la panadería.'
+      );
+      return;
+    }
+
     setFormData({
       ...formData,
       [e.target.name]: e.target.value
@@ -694,6 +1044,31 @@ const initSquareCard = useCallback(async () => {
         <h3 className="text-xl font-bold text-green-600 mb-2">¡Pedido Realizado Exitosamente!</h3>
         <p className="text-gray-600 mb-4">Gracias por tu pedido. Lo tendremos listo para recoger pronto.</p>
         <p className="text-sm text-gray-500">Redirigiendo al dashboard...</p>
+      </div>
+    );
+  }
+
+  if (quoteSubmitted) {
+    return (
+      <div className="bg-white rounded-xl shadow-lg p-8 text-center">
+        <div className="w-16 h-16 flex items-center justify-center bg-pink-100 rounded-full mx-auto mb-4">
+          <i className="ri-customer-service-2-line text-pink-500 text-2xl"></i>
+        </div>
+        <h3 className="text-xl font-bold text-pink-600 mb-2">¡Solicitud enviada!</h3>
+        <p className="text-gray-600 mb-3">
+          El propietario revisará tu personalización y se pondrá en contacto contigo con el precio final.
+        </p>
+        {quoteReference && (
+          <p className="text-sm text-gray-500 mb-4">
+            Código de referencia: <span className="font-mono text-pink-600">{quoteReference}</span>
+          </p>
+        )}
+        <button
+          onClick={() => router.push('/track')}
+          className="w-full bg-gradient-to-r from-pink-400 to-teal-400 text-white py-3 rounded-lg font-medium"
+        >
+          Ver mis órdenes
+        </button>
       </div>
     );
   }
@@ -1053,27 +1428,36 @@ const initSquareCard = useCallback(async () => {
                   <div className="flex-1">
                     <span className="font-medium text-sm">{item.name}</span>
                     <span className="text-pink-600 text-sm ml-2">{formatPrice(item)}</span>
+                    {getCustomizationDetails(item) && (
+                      <p className="text-xs text-gray-500 mt-1 whitespace-pre-line">
+                        {getCustomizationDetails(item)}
+                      </p>
+                    )}
                   </div>
                   <div className="flex items-center space-x-2">
                     <span className="text-sm text-gray-600">x{item.quantity}</span>
-                    <button
-                      type="button"
-                      onClick={() => addToCart(item)}
-                      className={`px-3 py-1 rounded-full text-xs font-medium transition-all ${
-                        addedItems.has(item.id)
-                          ? 'bg-green-500 text-white'
-                          : 'bg-gradient-to-r from-pink-400 to-teal-400 text-white hover:shadow-md'
-                      }`}
-                    >
-                      {addedItems.has(item.id) ? '¡Agregado!' : 'Agregar'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => removeFromCart(item.id, item.name)}
-                      className="px-3 py-1 rounded-full text-xs font-medium bg-red-500 text-white hover:bg-red-600"
-                    >
-                      Eliminar
-                    </button>
+                    {!existingOrder && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => addToCart(item)}
+                          className={`px-3 py-1 rounded-full text-xs font-medium transition-all ${
+                            addedItems.has(item.id)
+                              ? 'bg-green-500 text-white'
+                              : 'bg-gradient-to-r from-pink-400 to-teal-400 text-white hover:shadow-md'
+                          }`}
+                        >
+                          {addedItems.has(item.id) ? '¡Agregado!' : 'Agregar'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeFromCart(item.id, item.name)}
+                          className="px-3 py-1 rounded-full text-xs font-medium bg-red-500 text-white hover:bg-red-600"
+                        >
+                          Eliminar
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
               ))}
@@ -1105,7 +1489,10 @@ const initSquareCard = useCallback(async () => {
               value={formData.pickupTime}
               onChange={handleInputChange}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm"
+              disabled={Boolean(existingOrder)}
+              className={`w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm ${
+                existingOrder ? 'bg-gray-100 cursor-not-allowed' : ''
+              }`}
             >
               <option value="">Seleccionar hora de recogida</option>
               <option value="9:00 AM">9:00 AM</option>
@@ -1129,7 +1516,10 @@ const initSquareCard = useCallback(async () => {
               value={formData.specialRequests}
               onChange={handleInputChange}
               maxLength={500}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm h-20 resize-none"
+              disabled={Boolean(existingOrder)}
+              className={`w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent text-sm h-20 resize-none ${
+                existingOrder ? 'bg-gray-100 cursor-not-allowed' : ''
+              }`}
               placeholder="¿Alguna instrucción especial o requerimientos dietéticos?"
             />
             <p className="text-xs text-gray-500 mt-1">{formData.specialRequests.length}/500 caracteres</p>
@@ -1139,7 +1529,7 @@ const initSquareCard = useCallback(async () => {
             type="submit"
             className="w-full bg-gradient-to-r from-pink-400 to-teal-400 text-white py-3 rounded-lg font-medium"
           >
-            Continuar al Pago - ${calculateTotal()}
+            {existingOrder ? `Continuar con el pago - $${calculateTotal()}` : `Continuar al Pago - $${calculateTotal()}`}
           </button>
         </div>
 

--- a/app/order/page.tsx
+++ b/app/order/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import Header from '@/components/Header';
 import TabBar from '@/components/TabBar';
 import OrderForm from './OrderForm';
 import { getUser } from '@/lib/authStorage';
 
 export default function OrderPage() {
+  const searchParams = useSearchParams();
+  const existingOrderId = searchParams.get('orderId') ?? undefined;
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
   
@@ -84,7 +87,7 @@ export default function OrderPage() {
             Complete the form and we’ll prepare your delicious products.
           </p>
 
-<OrderForm />
+          <OrderForm orderId={existingOrderId} />
         </div>
       </div>
 

--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -369,14 +369,19 @@ export default function TrackOrderPage() {
                       </h4>
                       <div className="bg-gray-50 rounded-xl p-4 space-y-3">
                         {order.items.map((item, idx) => (
-                          <div key={idx} className="flex justify-between items-center">
-                            <div className="flex items-center space-x-3">
+                          <div key={idx} className="flex justify-between items-start space-x-3">
+                            <div className="flex items-start space-x-3">
                               <div className="w-8 h-8 bg-pink-100 rounded-full flex items-center justify-center text-pink-600 font-bold text-sm">
                                 {item.quantity}
                               </div>
-                              <span className="font-medium text-gray-700">{item.name}</span>
+                              <div>
+                                <span className="font-medium text-gray-700 block">{item.name}</span>
+                                {item.details && (
+                                  <p className="text-xs text-gray-500 whitespace-pre-line mt-1">{item.details}</p>
+                                )}
+                              </div>
                             </div>
-                            <span className="font-bold text-gray-800">{item.price}</span>
+                            <span className="font-bold text-gray-800">{typeof item.price === 'number' ? `$${item.price.toFixed(2)}` : item.price}</span>
                           </div>
                         ))}
                       </div>

--- a/lib/square/p2p.ts
+++ b/lib/square/p2p.ts
@@ -28,6 +28,7 @@ export async function createP2POrder(orderData: {
   userId: string;
   pickupTime?: string;
   specialRequests?: string;
+  orderId?: string;
 }) {
   try {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/lib/square/payments.ts
+++ b/lib/square/payments.ts
@@ -22,6 +22,10 @@ export type SquareOrderItem = {
   name: string;
   price: number; // unit price in dollars
   quantity: number;
+  photoUrl?: string | null;
+  details?: string | null;
+  type?: string | null;
+  customization?: any;
 };
 
 export interface SquareOrderData {
@@ -42,6 +46,9 @@ export interface SquareOrderData {
   pickupTime?: string | null;
   specialRequests?: string | null;
   currency?: 'USD';
+  subtotal?: number;
+  tax?: number;
+  orderId?: string;
 }
 
 // ---- Square payment (calls Supabase Edge Function) ----

--- a/supabase/functions/p2p-payment/index.ts
+++ b/supabase/functions/p2p-payment/index.ts
@@ -79,13 +79,67 @@ serve(async (req) => {
       const tax = 0
       const total = subtotal
 
+      const existingOrderId = orderData?.orderId
+      if (existingOrderId && isValidUUID(existingOrderId)) {
+        const { data: existingOrder, error: existingError } = await supabaseAdmin
+          .from('orders')
+          .select('special_requests')
+          .eq('id', existingOrderId)
+          .single()
+
+        if (existingError) {
+          throw new Error('Order not found for update')
+        }
+
+        const baseRequests = orderData.specialRequests
+          ? orderData.specialRequests.trim()
+          : (existingOrder?.special_requests || '').trim()
+
+        const updateData: Record<string, any> = {
+          items: orderData.items || [],
+          subtotal,
+          tax,
+          total,
+          p2p_reference: p2pRef,
+          payment_type: orderData.paymentMethod,
+          payment_status: 'pending',
+          updated_at: new Date().toISOString(),
+        }
+
+        updateData.special_requests = baseRequests
+          ? `${baseRequests}\n[Pagado con Zelle | Ref: ${p2pRef}]`
+          : `[Pagado con Zelle | Ref: ${p2pRef}]`
+
+        if (orderData.pickupTime !== undefined) {
+          updateData.pickup_time = orderData.pickupTime || null
+        }
+
+        const { error: updateError } = await supabaseAdmin
+          .from('orders')
+          .update(updateData)
+          .eq('id', existingOrderId)
+          .select('id, p2p_reference')
+          .single()
+
+        if (updateError) {
+          console.error('❌ Supabase update error:', updateError)
+          throw new Error(`Error actualizando orden: ${updateError.message}`)
+        }
+
+        return new Response(JSON.stringify({
+          success: true,
+          orderId: existingOrderId,
+          reference: p2pRef,
+          status: 'pending_payment',
+          amount: total,
+          paymentMethod: orderData.paymentMethod,
+          message: 'Orden actualizada. Esperando confirmación del propietario.'
+        }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+      }
+
       // ✅ CORRECCIÓN: NO incluir 'id' en el objeto
       const orderRecord: any = {
-        // ❌ id: orderId,  ← ELIMINAR ESTA LÍNEA
-        // ✅ Deja que PostgreSQL genere el UUID automáticamente
-
         user_id: profile.id,
-        // Provide default name to satisfy NOT NULL constraint in the DB
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || '',
         customer_email: orderData.customerInfo?.email?.trim() || null,
@@ -98,10 +152,10 @@ serve(async (req) => {
         special_requests: orderData.specialRequests
           ? `${orderData.specialRequests}\n[Pagado con Zelle | Ref: ${p2pRef}]`
           : `[Pagado con Zelle | Ref: ${p2pRef}]`,
-        
+
         // ✅ Asegurar que p2p_reference sea TEXT, no UUID
         p2p_reference: p2pRef,
-        
+
         status: 'pending',
         order_date: new Date().toISOString().split('T')[0],
         payment_type: orderData.paymentMethod,

--- a/supabase/functions/square-payment/index.ts
+++ b/supabase/functions/square-payment/index.ts
@@ -128,10 +128,67 @@ serve(async (req) => {
         throw new Error('Payment not completed');
       }
 
-      // === Guardar orden en DB ===
       const paymentId: string | undefined = paymentResult.id;
+      const amountValue = typeof orderData.amount === 'number' ? orderData.amount : 0;
+      const normalizedSubtotal =
+        typeof orderData?.subtotal === 'number' && !Number.isNaN(orderData.subtotal)
+          ? Math.round(orderData.subtotal * 100) / 100
+          : Math.round((amountValue - amountValue * 0.03) * 100) / 100;
+      const normalizedTax =
+        typeof orderData?.tax === 'number' && !Number.isNaN(orderData.tax)
+          ? Math.round(orderData.tax * 100) / 100
+          : Math.round((amountValue * 0.03) * 100) / 100;
 
-      // Validate userId before constructing order record
+      const existingOrderId = orderData?.orderId;
+      if (existingOrderId && isValidUUID(existingOrderId)) {
+        const updateData: Record<string, any> = {
+          items: orderData.items || [],
+          subtotal: normalizedSubtotal,
+          tax: normalizedTax,
+          total: Math.round(amountValue * 100) / 100,
+          payment_status: 'completed',
+          payment_type: orderData.paymentMethod || 'square',
+          payment_reference: paymentId,
+          payment_id: null,
+          updated_at: new Date().toISOString(),
+        };
+
+        if (orderData.pickupTime !== undefined) {
+          updateData.pickup_time = orderData.pickupTime || null;
+        }
+
+        if (orderData.specialRequests !== undefined) {
+          updateData.special_requests = orderData.specialRequests?.trim() || null;
+        }
+
+        const { error: updateError } = await supabaseAdmin
+          .from('orders')
+          .update(updateData)
+          .eq('id', existingOrderId)
+          .select('id')
+          .single();
+
+        if (updateError) {
+          console.error('❌ Database update error:', updateError);
+          throw new Error(`Payment ok but DB update error: ${updateError.message}`);
+        }
+
+        console.log('✅ Orden Square actualizada:', existingOrderId);
+
+        return new Response(JSON.stringify({
+          success: true,
+          paymentId: paymentResult.id,
+          orderId: existingOrderId,
+          status: 'completed',
+          amount: amountValue,
+          currency: 'USD',
+          environment: ENV,
+          paymentMethod: orderData.paymentMethod,
+          isSimulated: !ACCESS_TOKEN || !APPLICATION_ID,
+        }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      // === Guardar orden nueva en DB ===
       const userId = orderData?.userId;
       if (!userId || !isValidUUID(userId)) {
         throw new Error('Invalid or missing userId');
@@ -148,33 +205,30 @@ serve(async (req) => {
       }
 
       const orderRecord: Record<string, any> = {
-        // NO establezcas 'id' si tu columna es uuid con default
         user_id: profile.id,
-        // Ensure a non-null customer_name to satisfy DB constraints
         customer_name: orderData.customerInfo?.name?.trim() || 'Cliente',
         customer_phone: orderData.customerInfo?.phone?.trim() || '',
         customer_email: orderData.customerInfo?.email?.trim() || null,
         billing_address: orderData.customerInfo?.billingAddress?.trim() || null,
-        items: orderData.items,
-        subtotal: +(orderData.amount - orderData.amount * 0.03).toFixed(2),
-        tax: +(orderData.amount * 0.03).toFixed(2),
-        total: +orderData.amount.toFixed(2),
+        items: orderData.items || [],
+        subtotal: normalizedSubtotal,
+        tax: normalizedTax,
+        total: Math.round(amountValue * 100) / 100,
         pickup_time: orderData.pickupTime || null,
         special_requests: orderData.specialRequests?.trim() || null,
-        status: 'pending', // pendiente de producción
+        status: 'pending',
         order_date: new Date().toISOString().split('T')[0],
-        // Para payment_id, usar TEXT siempre (Square puede devolver IDs no-UUID)
-        payment_id: null,  // Deja null si no es UUID válido
-        payment_reference: paymentId, // Guarda el ID original aquí como TEXT
+        payment_id: null,
+        payment_reference: paymentId,
         payment_type: orderData.paymentMethod || 'square',
         payment_status: 'completed',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
-        };
+      };
       console.log('📋 Insertando orden Square:', {
         payment_reference: paymentId,
         user_id: orderRecord.user_id,
-        total: orderRecord.total
+        total: orderRecord.total,
       });
 
       const { data: insertedOrder, error: dbError } = await supabaseAdmin
@@ -193,9 +247,9 @@ serve(async (req) => {
       return new Response(JSON.stringify({
         success: true,
         paymentId: paymentResult.id,
-        orderId: insertedOrder.id, // ← id generado por la DB
+        orderId: insertedOrder.id,
         status: 'completed',
-        amount: orderData.amount,
+        amount: amountValue,
         currency: 'USD',
         environment: ENV,
         paymentMethod: orderData.paymentMethod,

--- a/supabase/migrations/20250202000000_add_cake_quote_fields.sql
+++ b/supabase/migrations/20250202000000_add_cake_quote_fields.sql
@@ -1,0 +1,5 @@
+alter table if exists quotes add column if not exists cart_items jsonb default '[]'::jsonb;
+alter table if exists quotes add column if not exists requires_cake_quote boolean default false;
+alter table if exists quotes add column if not exists pickup_time text;
+alter table if exists quotes add column if not exists special_requests text;
+alter table if exists quotes add column if not exists reference_code text;


### PR DESCRIPTION
## Summary
- add a quote-only checkout path for cake orders and let existing orders load for payment in the order form
- persist cake customization summaries, display them in the dashboard and tracking views, and capture them when finalizing a quote
- update Square/Zelle edge functions and add a migration so existing orders can be updated without inserting duplicates

## Testing
- npm run lint *(fails: existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c302cd608327aeeffed1c8575f66