### PR TITLE
Handle missing Supabase quote cart column gracefully

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -359,11 +359,28 @@ export default function DashboardPage() {
   const finalizeQuote = async (quote: Quote) => {
     try {
       const now = new Date().toISOString();
+      const fallbackItems = [
+        {
+          name: quote.occasion
+            ? `Cotización ${quote.occasion}`
+            : 'Cotización personalizada',
+          quantity: 1,
+          price: quote.estimated_price || 0,
+          details:
+            quote.event_details ||
+            'Detalle de cotización sin lista de carrito disponible.',
+        },
+      ];
+
+      const orderItems = quote.cart_items && quote.cart_items.length > 0
+        ? quote.cart_items
+        : fallbackItems;
+
       const orderData = {
         customer_name: quote.customer_name,
         customer_phone: quote.customer_phone || '',
         customer_email: quote.customer_email || '',
-        items: quote.cart_items || [],
+        items: orderItems,
         subtotal: quote.estimated_price || 0,
         tax: 0,
         total: quote.estimated_price || 0,


### PR DESCRIPTION
## Summary
- add graceful Supabase insert fallback when the quotes.cart_items column is unavailable and persist a readable cart snapshot
- keep sending owners the original cart data for notifications while allowing quote creation to succeed
- generate sensible order items when finalizing quotes that lack stored cart snapshots

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d5a3b85c8327a3af30caaf778f4c