### PR TITLE
Add automated quote notifications and contact capture

### DIFF
--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -27,6 +27,7 @@ serve(async (req) => {
       to,
       subject,
       orderData = {},
+      quoteData = {},
       type = 'order_confirmation',
       language = 'es'
     } = await req.json()
@@ -35,6 +36,25 @@ serve(async (req) => {
       ...orderData,
       items: Array.isArray(orderData?.items) ? orderData.items : []
     }
+    const quote = {
+      ...quoteData,
+      cart_items: Array.isArray(quoteData?.cart_items) ? quoteData.cart_items : [],
+      reference_code: quoteData?.reference_code || quoteData?.referenceCode || '',
+      event_details: quoteData?.event_details || quoteData?.eventDetails || ''
+    }
+    const quoteItems = Array.isArray(quote.cart_items) ? (quote.cart_items as any[]) : []
+    const quoteItemsHtml = quoteItems.length
+      ? quoteItems.map((item: any) => `
+          <li style="margin-bottom: 8px;">
+            <strong>${item.quantity || 1}x ${item.name || 'Artículo'}</strong>
+            ${item.price_label ? `<div style="color: #6b7280; font-size: 12px;">${item.price_label}</div>` : ''}
+            ${item.details ? `<div style="margin-top: 4px; color: #4b5563; white-space: pre-line;">${item.details}</div>` : ''}
+          </li>
+        `).join('')
+      : '<li style="color: #6b7280;">Sin desglose de artículos adjunto.</li>'
+    const formattedQuoteSummary = typeof quote.event_details === 'string'
+      ? quote.event_details.replace(/\n/g, '<br />')
+      : ''
 
     if (!RESEND_API_KEY) {
       console.log('RESEND_API_KEY not configured, simulating email send')
@@ -175,6 +195,112 @@ serve(async (req) => {
               </div>
             </div>
           `
+        },
+        new_quote: {
+          subject: subject || `Nueva cotización recibida - ${quote.reference_code || quote.customer_name || 'Cliente'}`,
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 640px; margin: 0 auto;">
+              <div style="background: linear-gradient(135deg, #c084fc, #6366f1); padding: 24px; text-align: center; color: white;">
+                <h1 style="margin: 0; font-size: 24px;">Nueva solicitud de cotización</h1>
+                <p style="margin: 8px 0 0 0;">Generada desde el personalizador de pasteles</p>
+              </div>
+              <div style="padding: 28px 24px; background: #ffffff;">
+                <div style="background: #f5f3ff; border-radius: 12px; padding: 18px; border: 1px solid #ddd6fe;">
+                  <p style="margin: 0; font-size: 18px; color: #4c1d95; font-weight: bold;">Referencia: ${quote.reference_code || 'Sin código'}</p>
+                  <p style="margin: 6px 0 0 0; color: #5b21b6;">Cliente: ${quote.customer_name || 'Cliente'}</p>
+                  ${quote.customer_phone ? `<p style="margin: 6px 0 0 0; color: #5b21b6;">Teléfono: ${quote.customer_phone}</p>` : ''}
+                  ${quote.customer_email ? `<p style="margin: 6px 0 0 0; color: #5b21b6;">Email: ${quote.customer_email}</p>` : ''}
+                </div>
+
+                ${quote.pickup_time ? `
+                  <div style="margin-top: 20px;">
+                    <p style="margin: 0; font-weight: bold; color: #4338ca;">Hora preferida de recogida:</p>
+                    <p style="margin: 4px 0 0 0; color: #312e81;">${quote.pickup_time}</p>
+                  </div>
+                ` : ''}
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #4338ca;">Resumen de la solicitud</h3>
+                  <div style="background: #eef2ff; border-radius: 10px; padding: 16px; color: #312e81; white-space: pre-line;">
+                    ${formattedQuoteSummary || 'Sin detalles adicionales proporcionados.'}
+                  </div>
+                </div>
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #4338ca;">Artículos personalizados</h3>
+                  <ul style="list-style: disc; padding-left: 20px; color: #1f2937;">
+                    ${quoteItemsHtml}
+                  </ul>
+                </div>
+
+                ${quote.special_requests ? `
+                  <div style="margin-top: 24px; background: #fffbeb; border-radius: 10px; padding: 16px; border: 1px solid #fef3c7;">
+                    <h4 style="margin: 0 0 8px 0; color: #92400e;">Solicitudes especiales</h4>
+                    <p style="margin: 0; color: #92400e; white-space: pre-line;">${quote.special_requests}</p>
+                  </div>
+                ` : ''}
+
+                <div style="margin-top: 28px; text-align: center;">
+                  <a href="https://app.rangersbakery.com/dashboard" style="display: inline-block; background: linear-gradient(135deg, #c084fc, #6366f1); color: white; padding: 12px 24px; border-radius: 9999px; text-decoration: none; font-weight: bold;">Ver en el panel</a>
+                </div>
+              </div>
+              <div style="background: #f3f4f6; padding: 18px; text-align: center; color: #6b7280; font-size: 12px;">
+                <p style="margin: 0;">Ranger's Bakery - Sistema de pedidos online</p>
+                <p style="margin: 6px 0 0 0;">Recibiste este mensaje porque está configurado como correo del negocio.</p>
+              </div>
+            </div>
+          `
+        },
+        customer_quote_confirmation: {
+          subject: subject || 'Hemos recibido tu personalización 🎉',
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 640px; margin: 0 auto;">
+              <div style="background: linear-gradient(135deg, #ec4899, #f97316); padding: 24px; text-align: center; color: white;">
+                <h1 style="margin: 0; font-size: 26px;">¡Gracias por tu solicitud!</h1>
+                <p style="margin: 8px 0 0 0;">Estamos preparando la cotización personalizada de tu pastel.</p>
+              </div>
+              <div style="padding: 28px 24px; background: #ffffff;">
+                <p style="font-size: 16px; color: #1f2937;">Hola ${quote.customer_name || 'amigo/a de Ranger Bakery'},</p>
+                <p style="color: #4b5563; line-height: 1.6;">
+                  Nuestro equipo revisará tu diseño y en menos de 24 horas te enviaremos el precio final por correo o teléfono.
+                </p>
+
+                <div style="background: #fdf2f8; border-radius: 12px; padding: 18px; border: 1px solid #fbcfe8;">
+                  <p style="margin: 0; color: #be185d; font-weight: bold;">Tu código de referencia</p>
+                  <p style="margin: 4px 0 0 0; color: #9d174d; font-size: 20px; letter-spacing: 1px; font-weight: bold;">${quote.reference_code || 'Pendiente'}</p>
+                  ${quote.pickup_time ? `<p style="margin: 8px 0 0 0; color: #be185d;">Hora preferida de recogida: ${quote.pickup_time}</p>` : ''}
+                </div>
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #db2777;">Resumen de tu pastel</h3>
+                  <ul style="list-style: disc; padding-left: 20px; color: #1f2937;">
+                    ${quoteItemsHtml}
+                  </ul>
+                </div>
+
+                ${formattedQuoteSummary ? `
+                  <div style="margin-top: 24px; background: #f3f4f6; border-radius: 10px; padding: 16px; color: #374151;">
+                    ${formattedQuoteSummary}
+                  </div>
+                ` : ''}
+
+                ${quote.special_requests ? `
+                  <div style="margin-top: 24px; background: #fff7ed; border-radius: 10px; padding: 16px; border: 1px solid #fed7aa;">
+                    <h4 style="margin: 0 0 8px 0; color: #b45309;">Tus notas</h4>
+                    <p style="margin: 0; color: #b45309; white-space: pre-line;">${quote.special_requests}</p>
+                  </div>
+                ` : ''}
+
+                <p style="margin-top: 28px; color: #4b5563; line-height: 1.6;">
+                  Te avisaremos por email tan pronto tengamos el precio listo. Si necesitas hacer cambios, responde a este correo o escríbenos por WhatsApp al <strong>(862) 233-7204</strong>.
+                </p>
+              </div>
+              <div style="background: #f3f4f6; padding: 18px; text-align: center; color: #6b7280; font-size: 12px;">
+                <p style="margin: 0;">Ranger's Bakery - Endulzando tus celebraciones</p>
+                <p style="margin: 6px 0 0 0;">Síguenos en Instagram @rangersbakery</p>
+              </div>
+            </div>
+          `
         }
       },
       en: {
@@ -297,6 +423,110 @@ serve(async (req) => {
               <div style="background: #f8fafc; padding: 18px; text-align: center; color: #94a3b8; font-size: 12px;">
                 <p style="margin: 0;">Ranger's Bakery - Online order system</p>
                 <p style="margin: 6px 0 0 0;">You are receiving this email because you are configured as the business contact.</p>
+              </div>
+            </div>
+          `
+        },
+        new_quote: {
+          subject: subject || `New quote request - ${quote.reference_code || quote.customer_name || 'Customer'}`,
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 640px; margin: 0 auto;">
+              <div style="background: linear-gradient(135deg, #60a5fa, #2563eb); padding: 24px; text-align: center; color: white;">
+                <h1 style="margin: 0; font-size: 24px;">New custom cake request</h1>
+                <p style="margin: 8px 0 0 0;">Submitted from the cake designer</p>
+              </div>
+              <div style="padding: 28px 24px; background: #ffffff;">
+                <div style="background: #dbeafe; border-radius: 12px; padding: 18px; border: 1px solid #bfdbfe;">
+                  <p style="margin: 0; font-size: 18px; color: #1d4ed8; font-weight: bold;">Reference: ${quote.reference_code || 'N/A'}</p>
+                  <p style="margin: 6px 0 0 0; color: #1e40af;">Customer: ${quote.customer_name || 'Customer'}</p>
+                  ${quote.customer_phone ? `<p style="margin: 6px 0 0 0; color: #1e40af;">Phone: ${quote.customer_phone}</p>` : ''}
+                  ${quote.customer_email ? `<p style="margin: 6px 0 0 0; color: #1e40af;">Email: ${quote.customer_email}</p>` : ''}
+                </div>
+
+                ${quote.pickup_time ? `
+                  <div style="margin-top: 20px;">
+                    <p style="margin: 0; font-weight: bold; color: #1d4ed8;">Preferred pickup time:</p>
+                    <p style="margin: 4px 0 0 0; color: #1e3a8a;">${quote.pickup_time}</p>
+                  </div>
+                ` : ''}
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #1d4ed8;">Request summary</h3>
+                  <div style="background: #eff6ff; border-radius: 10px; padding: 16px; color: #1e3a8a; white-space: pre-line;">
+                    ${formattedQuoteSummary || 'No additional event details provided.'}
+                  </div>
+                </div>
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #1d4ed8;">Requested items</h3>
+                  <ul style="list-style: disc; padding-left: 20px; color: #111827;">
+                    ${quoteItemsHtml}
+                  </ul>
+                </div>
+
+                ${quote.special_requests ? `
+                  <div style="margin-top: 24px; background: #fef9c3; border-radius: 10px; padding: 16px; border: 1px solid #fde047;">
+                    <h4 style="margin: 0 0 8px 0; color: #92400e;">Special notes</h4>
+                    <p style="margin: 0; color: #92400e; white-space: pre-line;">${quote.special_requests}</p>
+                  </div>
+                ` : ''}
+
+                <div style="margin-top: 28px; text-align: center;">
+                  <a href="https://app.rangersbakery.com/dashboard" style="display: inline-block; background: linear-gradient(135deg, #60a5fa, #2563eb); color: white; padding: 12px 24px; border-radius: 9999px; text-decoration: none; font-weight: bold;">Open dashboard</a>
+                </div>
+              </div>
+              <div style="background: #f3f4f6; padding: 18px; text-align: center; color: #6b7280; font-size: 12px;">
+                <p style="margin: 0;">Ranger's Bakery - Online ordering system</p>
+              </div>
+            </div>
+          `
+        },
+        customer_quote_confirmation: {
+          subject: subject || 'We received your cake request! 🎉',
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 640px; margin: 0 auto;">
+              <div style="background: linear-gradient(135deg, #ec4899, #6366f1); padding: 24px; text-align: center; color: white;">
+                <h1 style="margin: 0; font-size: 26px;">Thank you!</h1>
+                <p style="margin: 8px 0 0 0;">We are reviewing your custom cake design.</p>
+              </div>
+              <div style="padding: 28px 24px; background: #ffffff;">
+                <p style="font-size: 16px; color: #111827;">Hi ${quote.customer_name || 'Ranger Bakery friend'},</p>
+                <p style="color: #4b5563; line-height: 1.6;">
+                  Our team will review your request and send the final quote within the next 24 hours.
+                </p>
+
+                <div style="background: #ede9fe; border-radius: 12px; padding: 18px; border: 1px solid #ddd6fe;">
+                  <p style="margin: 0; color: #4338ca; font-weight: bold;">Your reference code</p>
+                  <p style="margin: 4px 0 0 0; color: #312e81; font-size: 20px; letter-spacing: 1px; font-weight: bold;">${quote.reference_code || 'Pending'}</p>
+                  ${quote.pickup_time ? `<p style="margin: 8px 0 0 0; color: #4338ca;">Preferred pickup time: ${quote.pickup_time}</p>` : ''}
+                </div>
+
+                <div style="margin-top: 24px;">
+                  <h3 style="margin: 0 0 10px 0; color: #6366f1;">Your cake summary</h3>
+                  <ul style="list-style: disc; padding-left: 20px; color: #111827;">
+                    ${quoteItemsHtml}
+                  </ul>
+                </div>
+
+                ${formattedQuoteSummary ? `
+                  <div style="margin-top: 24px; background: #f3f4f6; border-radius: 10px; padding: 16px; color: #374151;">
+                    ${formattedQuoteSummary}
+                  </div>
+                ` : ''}
+
+                ${quote.special_requests ? `
+                  <div style="margin-top: 24px; background: #fff7ed; border-radius: 10px; padding: 16px; border: 1px solid #fde68a;">
+                    <h4 style="margin: 0 0 8px 0; color: #b45309;">Your notes</h4>
+                    <p style="margin: 0; color: #b45309; white-space: pre-line;">${quote.special_requests}</p>
+                  </div>
+                ` : ''}
+
+                <p style="margin-top: 28px; color: #4b5563; line-height: 1.6;">
+                  We will email you the final quote soon. Need adjustments? Reply to this email or text us on WhatsApp at <strong>(862) 233-7204</strong>.
+                </p>
+              </div>
+              <div style="background: #f3f4f6; padding: 18px; text-align: center; color: #6b7280; font-size: 12px;">
+                <p style="margin: 0;">Ranger's Bakery - Bringing sweetness to your events</p>
               </div>
             </div>
           `


### PR DESCRIPTION
## Summary
- request contact details during custom cake checkout when a quote is required and persist updates to the user profile
- email customers a confirmation of their personalization request using the shared notification function
- trigger the existing send-quote-response edge function when staff responds to a quote and extend templates to cover quote notifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9e645c79c8327807fb5952111671b