### PR TITLE
Ensure quotes pickup time column is available

### DIFF
--- a/supabase/migrations/20250301000000_refresh_quotes_pickup_time.sql
+++ b/supabase/migrations/20250301000000_refresh_quotes_pickup_time.sql
@@ -1,0 +1,4 @@
+alter table if exists quotes
+  add column if not exists pickup_time text;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- add a follow-up migration to guarantee the quotes table includes the pickup_time column
- trigger a PostgREST schema cache reload so the new column is available immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac90c70f8832787324d1812d830c9