### PR TITLE
Improve localization coverage across public pages

### DIFF
--- a/app/cakes/[id]/CakeCustomizer.tsx
+++ b/app/cakes/[id]/CakeCustomizer.tsx
@@ -9,6 +9,7 @@ import TabBar from '../../../components/TabBar';
 import { supabase } from '../../../lib/supabase';
 import { showCartNotification } from '../../../lib/cartNotification';
 import SafeImage from '@/components/SafeImage';
+import { useLanguage } from '../../../lib/languageContext';
 
 interface CakeCustomizerProps {
   cakeId: string;
@@ -41,6 +42,8 @@ interface DecorationExtra {
 
 export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
   const router = useRouter();
+  const { t, language } = useLanguage();
+  const localize = (es: string, en: string) => (language === 'es' ? es : en);
   const [customizerMode, setCustomizerMode] = useState<'basic' | 'advanced'>('basic');
   const [currentStep, setCurrentStep] = useState(1);
   const [quantity, setQuantity] = useState(1);
@@ -68,32 +71,32 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
   // Datos de los pasteles usando imágenes reales - PRECIOS ACTUALIZADOS SEGÚN TABLA
   const cakeProducts = {
     'birthday-classic': {
-      name: 'Pastel de Cumpleaños Clásico',
+      name: localize('Pastel de Cumpleaños Clásico', 'Classic Birthday Cake'),
       basePrice: 20,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png'
     },
     'birthday-deluxe': {
-      name: 'Pastel de Cumpleaños Deluxe',
+      name: localize('Pastel de Cumpleaños Deluxe', 'Deluxe Birthday Cake'),
       basePrice: 30,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png'
     },
     'wedding-elegant': {
-      name: 'Pastel de Cumpleaños Elegante',
+      name: localize('Pastel Elegante de Boda', 'Elegant Wedding Cake'),
       basePrice: 55,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png'
     },
     'quince-princess': {
-      name: 'Pastel de Cumpleaños Princesa',
+      name: localize('Pastel Princesa de Quinceañera', 'Princess Quinceañera Cake'),
       basePrice: 35,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/04879db0557315e718d30f6f01a65327.png'
     },
     'photo-cake-basic': {
-      name: 'Pastel de Cumpleaños con Foto Básico',
+      name: localize('Pastel con Foto Básico', 'Basic Photo Cake'),
       basePrice: 25,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png'
     },
     'photo-cake-premium': {
-      name: 'Pastel de Cumpleaños con Foto Premium',
+      name: localize('Pastel con Foto Premium', 'Premium Photo Cake'),
       basePrice: 35,
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png'
     }
@@ -101,47 +104,47 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
 
   // Formas disponibles
   const shapeOptions: CakeOption[] = [
-    { id: 'round', name: 'Redondo', price: 0, icon: 'ri-circle-line' },
-    { id: 'square', name: 'Cuadrado', price: 0, icon: 'ri-stop-line' },
-    { id: 'rectangle', name: 'Rectangular', price: 0, icon: 'ri-rectangle-line' },
-    { id: 'heart', name: 'Corazón', price: 5, icon: 'ri-heart-line' }
+    { id: 'round', name: localize('Redondo', 'Round'), price: 0, icon: 'ri-circle-line' },
+    { id: 'square', name: localize('Cuadrado', 'Square'), price: 0, icon: 'ri-stop-line' },
+    { id: 'rectangle', name: localize('Rectangular', 'Rectangle'), price: 0, icon: 'ri-rectangle-line' },
+    { id: 'heart', name: localize('Corazón', 'Heart'), price: 5, icon: 'ri-heart-line' }
   ];
 
   // TAMAÑOS ACTUALIZADOS SEGÚN TABLA OFICIAL
   const sizeOptions = [
-    { id: '6', name: '6 pulgadas', price: 20, serves: '4-6 personas' },
-    { id: '8', name: '8 pulgadas', price: 30, serves: '8-10 personas' },
-    { id: '10', name: '10 pulgadas', price: 35, serves: '10-15 personas' },
-    { id: '12', name: '12 pulgadas', price: 55, serves: '20-25 personas' },
-    { id: '14', name: '14 pulgadas', price: 80, serves: '35-40 personas' }
+    { id: '6', name: localize('6 pulgadas', '6 inches'), price: 20, serves: localize('4-6 personas', 'Serves 4-6') },
+    { id: '8', name: localize('8 pulgadas', '8 inches'), price: 30, serves: localize('8-10 personas', 'Serves 8-10') },
+    { id: '10', name: localize('10 pulgadas', '10 inches'), price: 35, serves: localize('10-15 personas', 'Serves 10-15') },
+    { id: '12', name: localize('12 pulgadas', '12 inches'), price: 55, serves: localize('20-25 personas', 'Serves 20-25') },
+    { id: '14', name: localize('14 pulgadas', '14 inches'), price: 80, serves: localize('35-40 personas', 'Serves 35-40') }
   ];
 
   // Masas disponibles
   const flavorOptions: CakeOption[] = [
     { id: 'red-velvet', name: 'Red Velvet', price: 5, color: '#DC143C' },
-    { id: 'carrot', name: 'Zanahoria', price: 6, color: '#DEB887' },
-    { id: 'vanilla', name: 'Vainilla', price: 0, color: '#F5E6A3' },
-    { id: 'chocolate', name: 'Chocolate', price: 0, color: '#8B4513' }
+    { id: 'carrot', name: localize('Zanahoria', 'Carrot'), price: 6, color: '#DEB887' },
+    { id: 'vanilla', name: localize('Vainilla', 'Vanilla'), price: 0, color: '#F5E6A3' },
+    { id: 'chocolate', name: localize('Chocolate', 'Chocolate'), price: 0, color: '#8B4513' }
   ];
 
   // Colores de decoración
   const colorOptions: CakeOption[] = [
-    { id: 'white', name: 'Blanco', price: 0, color: '#FFFFFF' },
-    { id: 'pink', name: 'Rosa', price: 0, color: '#FF69B4' },
-    { id: 'blue', name: 'Azul', price: 0, color: '#4169E1' },
-    { id: 'purple', name: 'Morado', price: 0, color: '#9370DB' },
-    { id: 'green', name: 'Verde', price: 0, color: '#32CD32' },
-    { id: 'yellow', name: 'Amarillo', price: 0, color: '#FFD700' },
-    { id: 'red', name: 'Rojo', price: 0, color: '#DC143C' },
-    { id: 'gold', name: 'Dorado', price: 0, color: '#FFD700' },
-    { id: 'silver', name: 'Plateado', price: 0, color: '#C0C0C0' }
+    { id: 'white', name: localize('Blanco', 'White'), price: 0, color: '#FFFFFF' },
+    { id: 'pink', name: localize('Rosa', 'Pink'), price: 0, color: '#FF69B4' },
+    { id: 'blue', name: localize('Azul', 'Blue'), price: 0, color: '#4169E1' },
+    { id: 'purple', name: localize('Morado', 'Purple'), price: 0, color: '#9370DB' },
+    { id: 'green', name: localize('Verde', 'Green'), price: 0, color: '#32CD32' },
+    { id: 'yellow', name: localize('Amarillo', 'Yellow'), price: 0, color: '#FFD700' },
+    { id: 'red', name: localize('Rojo', 'Red'), price: 0, color: '#DC143C' },
+    { id: 'gold', name: localize('Dorado', 'Gold'), price: 0, color: '#FFD700' },
+    { id: 'silver', name: localize('Plateado', 'Silver'), price: 0, color: '#C0C0C0' }
   ];
 
   const formatOptionPricing = (price?: number) => {
     if (!price || price <= 0) {
-      return 'Incluido';
+      return t('included');
     }
-    return 'Cotización con la panadería';
+    return t('bakeryWillQuote');
   };
 
   // Rellenos disponibles
@@ -666,7 +669,7 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
     localStorage.setItem('bakery-cart', JSON.stringify(cart));
 
     // Mostrar confirmación visual
-    showCartNotification(`${cartItem.name} agregado al carrito`);
+    showCartNotification(t('itemAddedToCart').replace('{item}', cartItem.name));
 
     setTimeout(() => {
       setIsAdding(false);

--- a/app/cakes/page.tsx
+++ b/app/cakes/page.tsx
@@ -6,84 +6,156 @@ import Link from 'next/link';
 import Header from '../../components/Header';
 import TabBar from '../../components/TabBar';
 import SafeImage from '@/components/SafeImage';
+import { useLanguage } from '../../lib/languageContext';
 
 export default function CakesPage() {
-  // Pasteles disponibles usando las imágenes reales - PRECIOS CORREGIDOS SEGÚN TABLA
-  const cakes = [
-    {
-      id: 'birthday-classic',
-      name: 'Pastel de Cumpleaños Clásico',
-      basePrice: 20,
-      description:
-        'Pastel de cumpleaños personalizable con decoraciones coloridas y tradicionales',
-      image:
-        'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png',
-      category: 'birthday',
-      popular: true
-    },
-    {
-      id: 'birthday-deluxe',
-      name: 'Pastel de Cumpleaños Deluxe',
-      basePrice: 30,
-      description:
-        'Versión deluxe con decoraciones especiales y acabados profesionales',
-      image:
-        'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png',
-      category: 'birthday',
-      popular: false
-    },
-    {
-      id: 'wedding-elegant',
-      name: 'Pastel de Cumpleaños Elegante',
-      basePrice: 55,
-      description:
-        'Inspirado en bodas, con múltiples niveles y decoraciones elegantes',
-      image:
-        'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png',
-      category: 'wedding',
-      popular: true
-    },
-    {
-      id: 'quince-princess',
-      name: 'Pastel de Cumpleaños Princesa',
-      basePrice: 35,
-      description:
-        'Ideal para quinceañeras con toques principescos y colores vibrantes',
-      image:
-        'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/04879db0557315e718d30f6f01a65327.png',
-      category: 'quince',
-      popular: true
-    },
-    {
-      id: 'photo-cake-basic',
-      name: 'Pastel de Cumpleaños con Foto Básico',
-      basePrice: 25,
-      description:
-        'Añade tu foto favorita a un delicioso pastel de cumpleaños',
-      image: '',
-      category: 'photo',
-      popular: false
-    },
-    {
-      id: 'photo-cake-premium',
-      name: 'Pastel de Cumpleaños con Foto Premium',
-      basePrice: 35,
-      description:
-        'Versión premium con marco decorativo alrededor de tu foto personalizada',
-      image: '',
-      category: 'photo',
-      popular: false
-    }
-  ];
+  const { t, language } = useLanguage();
+
+  const cakeContent = {
+    es: [
+      {
+        id: 'birthday-classic',
+        name: 'Pastel de Cumpleaños Clásico',
+        basePrice: 20,
+        description:
+          'Pastel de cumpleaños personalizable con decoraciones coloridas y tradicionales',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png',
+        category: 'birthday',
+        popular: true
+      },
+      {
+        id: 'birthday-deluxe',
+        name: 'Pastel de Cumpleaños Deluxe',
+        basePrice: 30,
+        description:
+          'Versión deluxe con decoraciones especiales y acabados profesionales',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png',
+        category: 'birthday',
+        popular: false
+      },
+      {
+        id: 'wedding-elegant',
+        name: 'Pastel Elegante de Boda',
+        basePrice: 55,
+        description:
+          'Inspirado en bodas, con múltiples niveles y decoraciones elegantes',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png',
+        category: 'wedding',
+        popular: true
+      },
+      {
+        id: 'quince-princess',
+        name: 'Pastel Princesa de Quinceañera',
+        basePrice: 35,
+        description:
+          'Ideal para quinceañeras con toques principescos y colores vibrantes',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/04879db0557315e718d30f6f01a65327.png',
+        category: 'quince',
+        popular: true
+      },
+      {
+        id: 'photo-cake-basic',
+        name: 'Pastel con Foto Básico',
+        basePrice: 25,
+        description:
+          'Añade tu foto favorita a un delicioso pastel personalizado',
+        image: '',
+        category: 'photo',
+        popular: false
+      },
+      {
+        id: 'photo-cake-premium',
+        name: 'Pastel con Foto Premium',
+        basePrice: 35,
+        description:
+          'Versión premium con marco decorativo alrededor de tu foto personalizada',
+        image: '',
+        category: 'photo',
+        popular: false
+      }
+    ],
+    en: [
+      {
+        id: 'birthday-classic',
+        name: 'Classic Birthday Cake',
+        basePrice: 20,
+        description:
+          'Customizable birthday cake with colorful traditional decorations',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png',
+        category: 'birthday',
+        popular: true
+      },
+      {
+        id: 'birthday-deluxe',
+        name: 'Deluxe Birthday Cake',
+        basePrice: 30,
+        description:
+          'Deluxe version with special decorations and professional finishes',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png',
+        category: 'birthday',
+        popular: false
+      },
+      {
+        id: 'wedding-elegant',
+        name: 'Elegant Wedding Cake',
+        basePrice: 55,
+        description:
+          'Wedding-inspired cake with multiple tiers and elegant decorations',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png',
+        category: 'wedding',
+        popular: true
+      },
+      {
+        id: 'quince-princess',
+        name: 'Princess Quinceañera Cake',
+        basePrice: 35,
+        description:
+          'Perfect for quinceañeras with royal touches and vibrant colors',
+        image:
+          'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/04879db0557315e718d30f6f01a65327.png',
+        category: 'quince',
+        popular: true
+      },
+      {
+        id: 'photo-cake-basic',
+        name: 'Basic Photo Cake',
+        basePrice: 25,
+        description:
+          'Add your favorite photo to a delicious personalized cake',
+        image: '',
+        category: 'photo',
+        popular: false
+      },
+      {
+        id: 'photo-cake-premium',
+        name: 'Premium Photo Cake',
+        basePrice: 35,
+        description:
+          'Premium version with a decorative frame around your custom photo',
+        image: '',
+        category: 'photo',
+        popular: false
+      }
+    ]
+  } as const;
+
+  const cakes = cakeContent[language as keyof typeof cakeContent];
 
   const [selectedCategory, setSelectedCategory] = useState('all');
 
   const categories = [
-    { id: 'all', name: 'Todos', icon: 'ri-cake-3-line' },
-    { id: 'birthday', name: 'Cumpleaños', icon: 'ri-gift-line' },
-    { id: 'wedding', name: 'Bodas', icon: 'ri-heart-line' },
-    { id: 'quince', name: 'Quinceañera', icon: 'ri-star-line' },
-    { id: 'photo', name: 'Pastel con Foto', icon: 'ri-camera-line' }
+    { id: 'all', name: t('cakeCategoryAll'), icon: 'ri-cake-3-line' },
+    { id: 'birthday', name: t('cakeCategoryBirthday'), icon: 'ri-gift-line' },
+    { id: 'wedding', name: t('cakeCategoryWeddings'), icon: 'ri-heart-line' },
+    { id: 'quince', name: t('cakeCategoryQuince'), icon: 'ri-star-line' },
+    { id: 'photo', name: t('cakeCategoryPhoto'), icon: 'ri-camera-line' }
   ];
 
   const filteredCakes = selectedCategory === 'all' 
@@ -97,15 +169,15 @@ export default function CakesPage() {
         <div className="px-3 py-4">
           <Link href="/" className="inline-flex items-center text-pink-500 mb-4">
             <i className="ri-arrow-left-line mr-2"></i>
-            Volver al Inicio
+            {t('cakesBackLink')}
           </Link>
 
           <div className="text-center mb-6">
             <h1 className="text-2xl font-bold text-amber-800 mb-2">
-              Pasteles Personalizados
+              {t('cakesTitle')}
             </h1>
             <p className="text-gray-600 text-sm">
-              Crea el pastel perfecto para tu ocasión especial
+              {t('cakesSubtitle')}
             </p>
           </div>
 
@@ -137,7 +209,7 @@ export default function CakesPage() {
                   <div className="w-24 h-24 flex-shrink-0">
                     {cake.category === 'photo' ? (
                       <div className="flex items-center justify-center w-full h-full bg-pink-100 text-pink-500 text-xs text-center p-2">
-                        Envíanos tu foto 
+                        {t('sendUsYourPhoto')}
                       </div>
                     ) : (
                       <SafeImage
@@ -156,11 +228,11 @@ export default function CakesPage() {
                       <div className="flex-1">
                         <div className="flex items-center">
                           <h3 className="font-semibold text-gray-800 text-sm mb-1">
-                            {cake.name}
-                          </h3>
-                          {cake.popular && (
-                            <span className="ml-2 bg-pink-100 text-pink-600 text-xs px-2 py-0.5 rounded-full">
-                              Popular
+                          {cake.name}
+                        </h3>
+                        {cake.popular && (
+                          <span className="ml-2 bg-pink-100 text-pink-600 text-xs px-2 py-0.5 rounded-full">
+                              {t('popularTag')}
                             </span>
                           )}
                         </div>
@@ -169,11 +241,11 @@ export default function CakesPage() {
                         </p>
                         <div className="flex items-center justify-between">
                           <span className="text-lg font-bold text-pink-600">
-                            Desde ${cake.basePrice}
+                            {`${t('fromPrice')} $${cake.basePrice}`}
                           </span>
                           <Link href={`/cakes/${cake.id}`}>
                             <button className="bg-gradient-to-r from-pink-400 to-teal-400 text-white px-4 py-2 rounded-lg text-xs font-medium hover:shadow-md transition-all">
-                              Personalizar
+                              {t('customize')}
                             </button>
                           </Link>
                         </div>
@@ -188,7 +260,7 @@ export default function CakesPage() {
           {/* Info Section */}
           <div className="mt-8 bg-gradient-to-r from-amber-50 to-orange-50 rounded-xl p-6 border border-amber-200">
             <h3 className="font-bold text-amber-800 mb-3 text-center">
-              ¿Cómo funciona?
+              {t('howItWorks')}
             </h3>
             <div className="space-y-3 text-sm">
               <div className="flex items-start">
@@ -196,7 +268,7 @@ export default function CakesPage() {
                   <span className="text-pink-600 font-bold text-xs">1</span>
                 </div>
                 <p className="text-gray-700">
-                  <strong>Selecciona</strong> el tipo de pastel que más te guste
+                  {t('stepSelect')}
                 </p>
               </div>
               <div className="flex items-start">
@@ -204,7 +276,7 @@ export default function CakesPage() {
                   <span className="text-blue-600 font-bold text-xs">2</span>
                 </div>
                 <p className="text-gray-700">
-                  <strong>Personaliza</strong> forma, masas, colores y decoraciones
+                  {t('stepCustomize')}
                 </p>
               </div>
               <div className="flex items-start">
@@ -212,7 +284,7 @@ export default function CakesPage() {
                   <span className="text-green-600 font-bold text-xs">3</span>
                 </div>
                 <p className="text-gray-700">
-                  <strong>Ordena</strong> y nosotros lo preparamos especialmente para ti
+                  {t('stepOrder')}
                 </p>
               </div>
             </div>
@@ -220,13 +292,13 @@ export default function CakesPage() {
 
           {/* CTA */}
           <div className="mt-6 bg-gradient-to-r from-pink-400 to-teal-400 rounded-xl p-5 text-white text-center">
-            <h3 className="text-lg font-semibold mb-2">¿No encuentras lo que buscas?</h3>
+            <h3 className="text-lg font-semibold mb-2">{t('cantFindCta')}</h3>
             <p className="text-sm opacity-90 mb-4">
-              Contáctanos para crear un diseño completamente personalizado
+              {t('contactForCustom')}
             </p>
             <Link href="/quote">
               <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-3 rounded-full font-medium !rounded-button">
-                Solicitar Cotización
+                {t('requestQuote')}
               </button>
             </Link>
           </div>

--- a/app/menu/MenuSection.tsx
+++ b/app/menu/MenuSection.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { showCartNotification } from '../../lib/cartNotification';
 import SafeImage from '@/components/SafeImage';
+import { useLanguage } from '../../lib/languageContext';
 
 interface MenuItem {
   name: string;
@@ -18,6 +19,7 @@ interface MenuSectionProps {
 export default function MenuSection({ category, items }: MenuSectionProps) {
   const [quantities, setQuantities] = useState<{ [key: string]: number }>({});
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const { t } = useLanguage();
 
   useEffect(() => {
     checkAuthentication();
@@ -43,7 +45,7 @@ export default function MenuSection({ category, items }: MenuSectionProps) {
 
   const addToCart = (item: MenuItem) => {
     if (!isAuthenticated) {
-      alert('Necesitas crear una cuenta para agregar productos al carrito');
+      alert(t('loginRequiredForCart'));
       return;
     }
 
@@ -67,7 +69,7 @@ export default function MenuSection({ category, items }: MenuSectionProps) {
 
     localStorage.setItem('bakery-cart', JSON.stringify(existingCart));
 
-    showCartNotification(`${item.name} agregado al carrito`);
+    showCartNotification(t('itemAddedToCart').replace('{item}', item.name));
   };
 
   return (
@@ -124,7 +126,7 @@ export default function MenuSection({ category, items }: MenuSectionProps) {
                     className="bg-gradient-to-r from-pink-400 to-teal-400 text-white px-4 py-1.5 rounded-full text-sm font-medium !rounded-button hover:shadow-md transition-all"
                   >
                     <i className="ri-shopping-cart-line mr-1 text-xs"></i>
-                    Agregar
+                    {t('addToCart')}
                   </button>
                 </div>
               </div>

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -6,6 +6,7 @@ import TabBar from '../../components/TabBar';
 import MenuSection from './MenuSection';
 import Link from 'next/link';
 import { useState } from 'react';
+import { useLanguage } from '../../lib/languageContext';
 import gelatinaImg from '../../images/gelatina.jpeg';
 import flanImg from '../../images/flan.jpeg';
 import budinPanImg from '../../images/pudin de pan.jpeg';
@@ -29,20 +30,22 @@ import miniCannolisImg from '../../images/Cannolis.jpeg';
 
 
 export default function MenuPage() {
-  const [selectedCategory, setSelectedCategory] = useState('Todos');
+  const { t } = useLanguage();
+  const [selectedCategory, setSelectedCategory] = useState('all');
 
   const categories = [
-    'Todos',
-    'Postres Clásicos',
-    'Especialidades',
-    'Tropicales',
-    'Pequeños Placeres',
-    'Únicos'
+    { id: 'all', label: t('menuCategoryAll') },
+    { id: 'classics', label: t('menuCategoryClassics') },
+    { id: 'specialties', label: t('menuCategorySpecialties') },
+    { id: 'tropical', label: t('menuCategoryTropical') },
+    { id: 'smallDelights', label: t('menuCategorySmallDelights') },
+    { id: 'unique', label: t('menuCategoryUnique') }
   ];
 
   const menuItems = [
     {
-      category: 'Postres Clásicos',
+      categoryId: 'classics',
+      title: t('menuCategoryClassics'),
       items: [
         {
           name: 'Gelatina',
@@ -62,7 +65,8 @@ export default function MenuPage() {
       ]
     },
     {
-      category: 'Especialidades de la Casa',
+      categoryId: 'specialties',
+      title: t('menuCategorySpecialties'),
       items: [
         {
           name: 'Cheesecake',
@@ -92,7 +96,8 @@ export default function MenuPage() {
       ]
     },
     {
-      category: 'Productos Tropicales',
+      categoryId: 'tropical',
+      title: t('menuCategoryTropical'),
       items: [
         {
           name: 'Coco-Piña',
@@ -112,7 +117,8 @@ export default function MenuPage() {
       ]
     },
     {
-      category: 'Pequeños Placeres',
+      categoryId: 'smallDelights',
+      title: t('menuCategorySmallDelights'),
       items: [
         {
           name: 'Mantecaditos',
@@ -142,7 +148,8 @@ export default function MenuPage() {
       ]
     },
     {
-      category: 'Especialidades Únicas',
+      categoryId: 'unique',
+      title: t('menuCategoryUnique'),
       items: [
         {
           name: 'Mini Pasteles',
@@ -168,18 +175,9 @@ export default function MenuPage() {
     }
   ];
 
-  const getCategoryDisplayName = (category: string) => {
-    const categoryMap: { [key: string]: string } = {
-      'Especialidades de la Casa': 'Especialidades',
-      'Productos Tropicales': 'Tropicales',
-      'Especialidades Únicas': 'Únicos'
-    };
-    return categoryMap[category] || category;
-  };
-
-  const filteredMenuItems = selectedCategory === 'Todos' 
-    ? menuItems 
-    : menuItems.filter(section => getCategoryDisplayName(section.category) === selectedCategory);
+  const filteredMenuItems = selectedCategory === 'all'
+    ? menuItems
+    : menuItems.filter(section => section.categoryId === selectedCategory);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-pink-50 to-purple-50">
@@ -187,10 +185,10 @@ export default function MenuPage() {
       <div className="pt-16 pb-20">
         <div className="px-3 py-4">
           <h1 className="text-2xl font-bold text-amber-800 text-center mb-1">
-            Nuestro Menú
+            {t('menuTitle')}
           </h1>
           <p className="text-gray-600 text-center mb-6 text-sm">
-            Delicias dominicanas hechas con amor para ti
+            {t('menuSubtitle')}
           </p>
 
           {/* Category Filter */}
@@ -198,36 +196,36 @@ export default function MenuPage() {
             <div className="flex overflow-x-auto space-x-2 pb-2">
               {categories.map((category) => (
                 <button
-                  key={category}
-                  onClick={() => setSelectedCategory(category)}
+                  key={category.id}
+                  onClick={() => setSelectedCategory(category.id)}
                   className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                    selectedCategory === category
+                    selectedCategory === category.id
                       ? 'bg-gradient-to-r from-pink-400 to-teal-400 text-white shadow-md'
                       : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
                   }`}
                 >
-                  {category}
+                  {category.label}
                 </button>
               ))}
             </div>
           </div>
 
           {filteredMenuItems.map((section, index) => (
-            <MenuSection 
+            <MenuSection
               key={index}
-              category={section.category}
+              category={section.title}
               items={section.items}
             />
           ))}
 
           <div className="mt-6 bg-gradient-to-r from-pink-400 to-teal-400 rounded-xl p-5 text-white text-center mx-2">
-            <h3 className="text-lg font-semibold mb-2">¿Listo para ordenar?</h3>
+            <h3 className="text-lg font-semibold mb-2">{t('menuReadyToOrder')}</h3>
             <p className="text-sm opacity-90 mb-4">
-              Haz tu pedido y lo tendremos listo para ti
+              {t('menuReadyDescription')}
             </p>
             <Link href="/order">
               <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-3 rounded-full font-medium !rounded-button">
-                Hacer Pedido
+                {t('menuOrderButton')}
               </button>
             </Link>
           </div>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,21 +1,20 @@
 
 'use client';
 
+import { useLanguage } from '../lib/languageContext';
+
 export default function Contact() {
+  const { t } = useLanguage();
   return (
     <section className="py-16 px-4">
       <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-3xl font-bold text-amber-800 mb-4">
-          Contact Us
-        </h2>
-        <p className="text-gray-600 mb-8">
-          We&apos;d love to hear from you! Get in touch for custom orders or questions.
-        </p>
-        
+        <h2 className="text-3xl font-bold text-amber-800 mb-4">{t('contactTitle')}</h2>
+        <p className="text-gray-600 mb-8">{t('contactSubtitle')}</p>
+
         <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="text-left">
-              <h3 className="font-semibold text-amber-800 mb-4">Get in Touch</h3>
+              <h3 className="font-semibold text-amber-800 mb-4">{t('contactSectionGetInTouch')}</h3>
               <div className="space-y-3">
                 <div className="flex items-center">
                   <div className="w-8 h-8 flex items-center justify-center">
@@ -43,12 +42,12 @@ export default function Contact() {
                 </div>
               </div>
             </div>
-            
+
             <div className="text-left">
-              <h3 className="font-semibold text-amber-800 mb-4">Follow Us</h3>
+              <h3 className="font-semibold text-amber-800 mb-4">{t('contactSectionFollowUs')}</h3>
               <div className="space-y-3">
-                <a 
-                  href="https://www.instagram.com/rangersbakery/" 
+                <a
+                  href="https://www.instagram.com/rangersbakery/"
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="flex items-center hover:text-pink-500 transition-colors"
@@ -70,18 +69,16 @@ export default function Contact() {
         </div>
 
         <div className="bg-gradient-to-r from-pink-400 to-teal-400 rounded-xl p-6 text-white">
-          <h3 className="text-lg font-semibold mb-2">Follow us on Instagram!</h3>
-          <p className="text-sm opacity-90 mb-4">
-            See our latest creations and behind-the-scenes moments
-          </p>
-          <a 
-            href="https://www.instagram.com/rangersbakery/" 
-            target="_blank" 
+          <h3 className="text-lg font-semibold mb-2">{t('contactInstagramSectionTitle')}</h3>
+          <p className="text-sm opacity-90 mb-4">{t('contactInstagramDescription')}</p>
+          <a
+            href="https://www.instagram.com/rangersbakery/"
+            target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center bg-white/20 backdrop-blur-sm text-white px-6 py-3 rounded-full font-medium !rounded-button hover:bg-white/30 transition-colors"
           >
             <i className="ri-instagram-line mr-2"></i>
-            Follow @rangersbakery
+            {t('contactInstagramButton')}
           </a>
         </div>
       </div>

--- a/components/Gallery.tsx
+++ b/components/Gallery.tsx
@@ -2,48 +2,76 @@
 'use client';
 
 import { useState } from 'react';
+import { useLanguage } from '../lib/languageContext';
 import SafeImage from './SafeImage';
 export default function Gallery() {
   const [showModal, setShowModal] = useState(false);
   const [selectedImage, setSelectedImage] = useState('');
+  const { t, language } = useLanguage();
 
   // Galería usando las imágenes reales de los pasteles
-  const galleryImages = [
+  const altTexts = {
+    es: {
+      strawberryCake: 'Pastel de cumpleaños con fresas',
+      elaineCake: 'Pastel de cumpleaños para Elaine',
+      quinceCake: 'Pastel de quinceañera',
+      decoratedCake: 'Pastel de cumpleaños decorado',
+      tresLechesCup: 'Tres Leches en Vaso',
+      cheesecake: 'Cheesecake dominicano',
+      tresLechesOreo: 'Tres Leches de Oreo',
+      flan: 'Flan casero dominicano'
+    },
+    en: {
+      strawberryCake: 'Strawberry birthday cake',
+      elaineCake: "Elaine's birthday cake",
+      quinceCake: 'Quinceañera cake',
+      decoratedCake: 'Decorated birthday cake',
+      tresLechesCup: 'Tres Leches in a cup',
+      cheesecake: 'Dominican cheesecake',
+      tresLechesOreo: 'Oreo Tres Leches',
+      flan: 'Homemade Dominican flan'
+    }
+  } as const;
+
+  type AltKey = keyof typeof altTexts.es;
+
+  const galleryImages: { src: string; altKey: AltKey }[] = [
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png',
-      alt: 'Pastel de cumpleaños con fresas'
+      altKey: 'strawberryCake'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/def4b1d4d19f7bb63fe8ed7acc40b9e6.png',
-      alt: 'Pastel de cumpleaños para Elaine'
+      altKey: 'elaineCake'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/b55c6989623b0711cfe5124c88d92ed0.png',
-      alt: 'Pastel de quinceañera'
+      altKey: 'quinceCake'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/04879db0557315e718d30f6f01a65327.png',
-      alt: 'Pastel de cumpleaños decorado'
+      altKey: 'decoratedCake'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/6e38ec235b30b7a74f673bc044a87814.jfif',
-      alt: 'Tres Leches en Vaso'
+      altKey: 'tresLechesCup'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/ae1f7420251af709ef833638a428a131.jfif',
-      alt: 'Cheesecake dominicano'
+      altKey: 'cheesecake'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/3426923c2c21bd56dac155cac89400e3.jfif',
-      alt: 'Tres Leches de Oreo'
+      altKey: 'tresLechesOreo'
     },
     {
       src: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/33b32b1e5581c150ed0666763a12e667.jfif',
-      alt: 'Flan casero dominicano'
+      altKey: 'flan'
     }
   ];
 
   const activeImage = galleryImages.find(image => image.src === selectedImage) || galleryImages[0];
+  const currentAltTexts = altTexts[language as keyof typeof altTexts];
 
   const openModal = (imageSrc: string) => {
     setSelectedImage(imageSrc);
@@ -58,7 +86,7 @@ export default function Gallery() {
   return (
     <section className="px-4 py-8">
       <h3 className="text-2xl font-bold text-amber-800 mb-6 text-center">
-        Galería de Nuestras Creaciones
+        {t('galleryTitle')}
       </h3>
 
       <div className="grid grid-cols-2 gap-4 mb-6">
@@ -70,7 +98,7 @@ export default function Gallery() {
           >
             <SafeImage
               src={image.src}
-              alt={image.alt}
+              alt={currentAltTexts[image.altKey]}
               fill
               className="object-cover transition-transform duration-300 hover:scale-105"
               sizes="(max-width: 768px) 45vw, 25vw"
@@ -84,7 +112,7 @@ export default function Gallery() {
           onClick={() => openModal(galleryImages[0].src)}
           className="bg-white border-2 border-pink-300 text-pink-500 px-5 py-2 rounded-xl font-medium shadow-sm hover:bg-pink-50 transition-colors text-sm"
         >
-          Ver Más Fotos
+          {t('viewMorePhotos')}
         </button>
       </div>
 
@@ -101,14 +129,14 @@ export default function Gallery() {
 
             <div className="p-4">
               <h4 className="text-xl font-bold text-amber-800 mb-4 text-center">
-                Nuestras Creaciones
+                {t('galleryModalTitle')}
               </h4>
 
               {activeImage && (
                 <div className="relative mb-4 w-full max-h-80">
                   <SafeImage
                     src={activeImage.src}
-                    alt={activeImage.alt}
+                    alt={currentAltTexts[activeImage.altKey]}
                     width={960}
                     height={540}
                     className="w-full h-auto object-cover rounded-lg"
@@ -122,7 +150,7 @@ export default function Gallery() {
                   <div key={index} className="relative aspect-video rounded-lg overflow-hidden">
                     <SafeImage
                       src={image.src}
-                      alt={image.alt}
+                      alt={currentAltTexts[image.altKey]}
                       fill
                       className="object-cover"
                       sizes="(max-width: 1024px) 40vw, 20vw"
@@ -139,7 +167,7 @@ export default function Gallery() {
                   className="inline-flex items-center bg-gradient-to-r from-pink-400 to-teal-400 text-white px-5 py-2.5 rounded-xl font-medium hover:shadow-md transition-all text-sm"
                 >
                   <i className="ri-instagram-line mr-2 text-base"></i>
-                  Ver más en Instagram
+                  {t('galleryInstagramCta')}
                 </a>
               </div>
             </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -37,13 +37,13 @@ export default function Hero() {
         3. O edita las traducciones en lib/languages.ts para cambiar automáticamente
         */}
         <h2 className="text-3xl font-bold text-gray-800 mb-3">{t('bakeryName')}</h2>
-        <p className="text-gray-600 mb-6 leading-relaxed">Hechas con amor para tus momentos especiales</p>
+        <p className="text-gray-600 mb-6 leading-relaxed">{t('heroSubtitle')}</p>
         
         <Link 
           href="/menu"
           className="inline-block bg-gradient-to-r from-amber-600 to-amber-700 text-white px-6 py-2.5 rounded-full font-medium shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 text-sm"
         >
-          Ver Menú
+          {t('seeFullMenu')}
         </Link>
       </div>
     </section>

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -12,7 +12,7 @@ interface LanguageSelectorProps {
 }
 
 export default function LanguageSelector({ showWelcome = false, onComplete }: LanguageSelectorProps) {
-  const { language, setLanguage } = useLanguage();
+  const { language, setLanguage, t } = useLanguage();
   const [showDropdown, setShowDropdown] = useState(false);
 
   const handleLanguageSelect = (langCode: string) => {
@@ -40,10 +40,10 @@ export default function LanguageSelector({ showWelcome = false, onComplete }: La
           </div>
           
           <h2 className="text-xl font-bold text-amber-800 mb-2">
-            Welcome to Ranger&apos;s Bakery
+            {t('languageWelcomeTitle')}
           </h2>
           <p className="text-gray-600 mb-6 text-sm">
-            Please select your preferred language / Por favor selecciona tu idioma preferido
+            {t('languageWelcomeDescription')}
           </p>
           
           <div className="space-y-3">

--- a/components/MenuPreview.tsx
+++ b/components/MenuPreview.tsx
@@ -19,36 +19,36 @@ export default function MenuPreview() {
   const featuredItems = [
     {
       id: 1,
-      name: 'Tres Leches en Vaso',
+      name: t('productTresLechesVasoName'),
       price: '$5.00',
-      description: 'Tradicional tres leches dominicano servido en vaso',
+      description: t('productTresLechesVasoDescription'),
       image: tresLechesVasoImg.src,
       category: 'dessert',
       type: 'dessert'
     },
     {
       id: 2,
-      name: 'Flan',
+      name: t('productFlanName'),
       price: '$4.00',
-      description: 'Cremoso flan casero dominicano con caramelo',
+      description: t('productFlanDescription'),
       image: flanImg.src,
       category: 'dessert',
       type: 'dessert'
     },
     {
       id: 3,
-      name: 'Cheesecake',
+      name: t('productCheesecakeName'),
       price: '$5.00',
-      description: 'Cremoso cheesecake estilo dominicano',
+      description: t('productCheesecakeDescription'),
       image: cheesecakeImg.src,
       category: 'dessert',
       type: 'dessert'
     },
     {
       id: 4,
-      name: 'Cake de Cumpleaños',
-      price: 'Cotización personalizada',
-      description: 'Cake personalizado con decoración especial',
+      name: t('productBirthdayCakeName'),
+      price: t('priceCustomQuote'),
+      description: t('productBirthdayCakeDescription'),
       image: 'https://static.readdy.ai/image/9733c14590fa269b3349cd88bac6322e/58a3f870af7fe55c1b2733bc57137538.png',
       category: 'cake',
       type: 'cake',
@@ -56,18 +56,18 @@ export default function MenuPreview() {
     },
     {
       id: 5,
-      name: 'Mini Pasteles',
+      name: t('productMiniPastelesName'),
       price: '$2.50',
-      description: 'Pequeños pasteles dominicanos con frutas variadas',
+      description: t('productMiniPastelesDescription'),
       image: miniPastelesImg.src,
       category: 'dessert',
       type: 'dessert'
     },
     {
       id: 6,
-      name: 'Tres Leches de Oreo',
+      name: t('productTresLechesOreoName'),
       price: '$5.00',
-      description: 'Nuestra versión especial dominicana con galletas Oreo',
+      description: t('productTresLechesOreoDescription'),
       image: tresLechesOreoImg.src,
       category: 'dessert',
       type: 'dessert'
@@ -78,7 +78,7 @@ export default function MenuPreview() {
     // Verificar autenticación primero
     const user = getUser();
     if (!user) {
-      alert('Necesitas crear una cuenta para agregar productos al carrito');
+      alert(t('loginRequiredForCart'));
       return;
     }
 
@@ -113,11 +113,11 @@ export default function MenuPreview() {
       localStorage.setItem('bakery-cart', JSON.stringify(cart));
       
       // Mostrar confirmación con animación consistente
-      showCartNotification(`${item.name} agregado al carrito`);
-      
+      showCartNotification(t('itemAddedToCart').replace('{item}', item.name));
+
     } catch (error) {
       console.error('Error agregando al carrito:', error);
-      alert('Error al agregar al carrito. Intenta de nuevo.');
+      alert(t('addToCartError'));
     }
   };
 
@@ -145,13 +145,13 @@ export default function MenuPreview() {
               <p className="text-gray-600 text-sm mb-2 line-clamp-2">{item.description}</p>
               <div className="flex items-center justify-between">
                 <span className={`text-lg font-bold ${item.type === 'cake' ? 'text-amber-600' : 'text-pink-600'}`}>
-                  {item.type === 'cake' ? 'Precio definido por la panadería' : item.price}
+                  {item.type === 'cake' ? t('priceDefinedByBakery') : item.price}
                 </span>
-                <button 
+                <button
                   className="bg-gradient-to-r from-pink-400 to-teal-400 text-white px-3 py-1.5 rounded-lg text-xs font-medium hover:shadow-md transition-all"
                   onClick={() => handleAddToCart(item)}
                 >
-                  {item.type === 'cake' ? 'Personalizar' : t('addToCart')}
+                  {item.type === 'cake' ? t('customize') : t('addToCart')}
                 </button>
               </div>
             </div>

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -23,7 +23,27 @@ export const translations = {
     featuredProducts: "Productos Destacados",
     seeFullMenu: "Ver Menú Completo",
     addToCart: "Agregar",
-    
+    heroSubtitle: "Hechas con amor para tus momentos especiales",
+
+    // Gallery
+    galleryTitle: "Galería de Nuestras Creaciones",
+    viewMorePhotos: "Ver Más Fotos",
+    galleryModalTitle: "Nuestras Creaciones",
+    galleryInstagramCta: "Ver más en Instagram",
+
+    // Contact
+    contactTitle: "Contáctanos",
+    contactSubtitle: "¡Nos encantaría saber de ti! Escríbenos para pedidos personalizados o preguntas.",
+    contactGetInTouch: "Ponte en contacto",
+    contactFollowUs: "Síguenos",
+    contactInstagramSectionTitle: "¡Síguenos en Instagram!",
+    contactInstagramDescription: "Mira nuestras últimas creaciones y momentos detrás de cámara",
+    contactInstagramButton: "Seguir @rangersbakery",
+
+    // Language selector
+    languageWelcomeTitle: "Bienvenido a Ranger's Bakery",
+    languageWelcomeDescription: "Selecciona tu idioma preferido",
+
     // PWA Install
     installApp: "¡Instala nuestra App!",
     installDescription: "Accede más rápido a nuestros deliciosos pasteles",
@@ -101,7 +121,9 @@ export const translations = {
     backToCakes: "Volver a los Pasteles",
     cakeCustomization: "Personalización del Pastel",
     requires24Hours: "Requiere 24 horas de anticipación",
-    
+    priceDefinedByBakery: "Precio definido por la panadería",
+    priceConfirmedLater: "El precio final será confirmado por la panadería después de revisar tu personalización",
+
     // Reviews
     clientReviews: "Reseñas de Clientes",
     basedOnReviews: "Basado en {count} reseñas",
@@ -122,7 +144,64 @@ export const translations = {
     no: "No",
     pleaseWait: "Por favor espera...",
     error: "Error",
-    success: "Éxito"
+    success: "Éxito",
+    included: "Incluido",
+    bakeryWillQuote: "Cotización con la panadería",
+    loginRequiredForCart: "Necesitas crear una cuenta para agregar productos al carrito",
+    addToCartError: "Error al agregar al carrito. Intenta de nuevo.",
+    itemAddedToCart: "{item} agregado al carrito",
+
+    // Menu Page
+    menuTitle: "Nuestro Menú",
+    menuSubtitle: "Delicias dominicanas hechas con amor para ti",
+    menuReadyToOrder: "¿Listo para ordenar?",
+    menuReadyDescription: "Haz tu pedido y lo tendremos listo para ti",
+    menuOrderButton: "Hacer Pedido",
+    menuCategoryAll: "Todos",
+    menuCategoryClassics: "Postres Clásicos",
+    menuCategorySpecialties: "Especialidades",
+    menuCategoryTropical: "Tropicales",
+    menuCategorySmallDelights: "Pequeños Placeres",
+    menuCategoryUnique: "Únicos",
+
+    // Menu Items
+    productTresLechesVasoName: "Tres Leches en Vaso",
+    productTresLechesVasoDescription: "Tradicional tres leches dominicano servido en vaso",
+    productFlanName: "Flan",
+    productFlanDescription: "Cremoso flan casero dominicano con caramelo",
+    productCheesecakeName: "Cheesecake",
+    productCheesecakeDescription: "Cremoso cheesecake estilo dominicano",
+    productBirthdayCakeName: "Cake de Cumpleaños",
+    productBirthdayCakeDescription: "Cake personalizado con decoración especial",
+    productMiniPastelesName: "Mini Pasteles",
+    productMiniPastelesDescription: "Pequeños pasteles dominicanos con frutas variadas",
+    productTresLechesOreoName: "Tres Leches de Oreo",
+    productTresLechesOreoDescription: "Nuestra versión especial dominicana con galletas Oreo",
+    priceCustomQuote: "Cotización personalizada",
+
+    // Cakes page
+    cakesBackLink: "Volver al Inicio",
+    cakesTitle: "Pasteles Personalizados",
+    cakesSubtitle: "Crea el pastel perfecto para tu ocasión especial",
+    cakeCategoryAll: "Todos",
+    cakeCategoryBirthday: "Cumpleaños",
+    cakeCategoryWeddings: "Bodas",
+    cakeCategoryQuince: "Quinceañera",
+    cakeCategoryPhoto: "Pastel con Foto",
+    sendUsYourPhoto: "Envíanos tu foto",
+    popularTag: "Popular",
+    fromPrice: "Desde",
+    howItWorks: "¿Cómo funciona?",
+    stepSelect: "Selecciona el tipo de pastel que más te guste",
+    stepCustomize: "Personaliza forma, masas, colores y decoraciones",
+    stepOrder: "Ordena y nosotros lo preparamos especialmente para ti",
+    cantFindCta: "¿No encuentras lo que buscas?",
+    contactForCustom: "Contáctanos para crear un diseño completamente personalizado",
+
+    // Contact info labels
+    contactSectionGetInTouch: "Ponte en contacto",
+    contactSectionFollowUs: "Síguenos",
+    contactFollowButton: "Seguir @rangersbakery"
   },
   en: {
     // Header
@@ -136,7 +215,27 @@ export const translations = {
     featuredProducts: "Featured Products",
     seeFullMenu: "See Full Menu",
     addToCart: "Add",
-    
+    heroSubtitle: "Made with love for your special moments",
+
+    // Gallery
+    galleryTitle: "Gallery of Our Creations",
+    viewMorePhotos: "View More Photos",
+    galleryModalTitle: "Our Creations",
+    galleryInstagramCta: "See more on Instagram",
+
+    // Contact
+    contactTitle: "Contact Us",
+    contactSubtitle: "We'd love to hear from you! Reach out for custom orders or questions.",
+    contactGetInTouch: "Get in Touch",
+    contactFollowUs: "Follow Us",
+    contactInstagramSectionTitle: "Follow us on Instagram!",
+    contactInstagramDescription: "See our latest creations and behind-the-scenes moments",
+    contactInstagramButton: "Follow @rangersbakery",
+
+    // Language selector
+    languageWelcomeTitle: "Welcome to Ranger's Bakery",
+    languageWelcomeDescription: "Please select your preferred language",
+
     // PWA Install
     installApp: "Install our App!",
     installDescription: "Get faster access to our delicious cakes",
@@ -214,7 +313,9 @@ export const translations = {
     backToCakes: "Back to Cakes",
     cakeCustomization: "Cake Customization",
     requires24Hours: "Requires 24 hours notice",
-    
+    priceDefinedByBakery: "Price determined by the bakery",
+    priceConfirmedLater: "The final price will be confirmed by the bakery after reviewing your customization",
+
     // Reviews
     clientReviews: "Client Reviews",
     basedOnReviews: "Based on {count} reviews",
@@ -235,7 +336,64 @@ export const translations = {
     no: "No",
     pleaseWait: "Please wait...",
     error: "Error",
-    success: "Success"
+    success: "Success",
+    included: "Included",
+    bakeryWillQuote: "Bakery will provide quote",
+    loginRequiredForCart: "You need to create an account to add products to the cart",
+    addToCartError: "Error adding to cart. Please try again.",
+    itemAddedToCart: "{item} added to cart",
+
+    // Menu Page
+    menuTitle: "Our Menu",
+    menuSubtitle: "Dominican delights made with love for you",
+    menuReadyToOrder: "Ready to order?",
+    menuReadyDescription: "Place your order and we'll have it ready for you",
+    menuOrderButton: "Place Order",
+    menuCategoryAll: "All",
+    menuCategoryClassics: "Classic Desserts",
+    menuCategorySpecialties: "Specialties",
+    menuCategoryTropical: "Tropical",
+    menuCategorySmallDelights: "Small Delights",
+    menuCategoryUnique: "Unique",
+
+    // Menu Items
+    productTresLechesVasoName: "Tres Leches in a Cup",
+    productTresLechesVasoDescription: "Traditional Dominican tres leches served in a cup",
+    productFlanName: "Flan",
+    productFlanDescription: "Creamy homemade Dominican flan with caramel",
+    productCheesecakeName: "Cheesecake",
+    productCheesecakeDescription: "Creamy Dominican-style cheesecake",
+    productBirthdayCakeName: "Birthday Cake",
+    productBirthdayCakeDescription: "Personalized cake with special decoration",
+    productMiniPastelesName: "Mini Cakes",
+    productMiniPastelesDescription: "Small Dominican cakes with assorted fruits",
+    productTresLechesOreoName: "Oreo Tres Leches",
+    productTresLechesOreoDescription: "Our special Dominican version with Oreo cookies",
+    priceCustomQuote: "Custom quote",
+
+    // Cakes page
+    cakesBackLink: "Back to Home",
+    cakesTitle: "Custom Cakes",
+    cakesSubtitle: "Create the perfect cake for your special occasion",
+    cakeCategoryAll: "All",
+    cakeCategoryBirthday: "Birthday",
+    cakeCategoryWeddings: "Weddings",
+    cakeCategoryQuince: "Quinceañera",
+    cakeCategoryPhoto: "Photo Cake",
+    sendUsYourPhoto: "Send us your photo",
+    popularTag: "Popular",
+    fromPrice: "From",
+    howItWorks: "How does it work?",
+    stepSelect: "Select the cake type you love the most",
+    stepCustomize: "Customize shape, flavors, colors and decorations",
+    stepOrder: "Place your order and we'll prepare it especially for you",
+    cantFindCta: "Can't find what you're looking for?",
+    contactForCustom: "Contact us to create a fully custom design",
+
+    // Contact info labels
+    contactSectionGetInTouch: "Get in Touch",
+    contactSectionFollowUs: "Follow Us",
+    contactFollowButton: "Follow @rangersbakery"
   }
 };
 


### PR DESCRIPTION
## Summary
- expand language dictionary with menu, gallery, contact, and cakes terminology
- translate landing, menu, gallery, and contact components to react to language changes
- localize cake listings and options data while wiring translations through cart interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daf638c0088327bf80bdc7525e7702