### PR TITLE
Handle missing billing address column and save profile phones

### DIFF
--- a/lib/authStorage.ts
+++ b/lib/authStorage.ts
@@ -2,6 +2,7 @@ export interface StoredUser {
   id: string;
   email: string;
   fullName?: string;
+  phone?: string;
   isOwner?: boolean;
   role?: string;
   expiresAt: number;

--- a/supabase/migrations/20250312090000_add_phone_to_profiles.sql
+++ b/supabase/migrations/20250312090000_add_phone_to_profiles.sql
@@ -1,0 +1,5 @@
+-- Ensure the profiles table can store customer phone numbers
+alter table profiles
+  add column if not exists phone text;
+
+comment on column profiles.phone is 'Primary contact phone number for the user profile';


### PR DESCRIPTION
## Summary
- collect and validate phone numbers during signup while storing them on customer profiles and local cache
- sync phone numbers from orders back to profiles and retry order inserts when the `billing_address` column is missing
- update Supabase edge functions and migrations to add the profile phone column and gracefully handle absent billing data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db00c011588327ad120923fe2a534a