### PR TITLE
Improve special request formatting on order tracker

### DIFF
--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -36,6 +36,52 @@ interface Order {
   updated_at?: string;
 }
 
+interface SpecialRequestEntry {
+  label?: string;
+  value: string;
+}
+
+const formatSpecialRequests = (specialRequests?: string): SpecialRequestEntry[] => {
+  if (!specialRequests) {
+    return [];
+  }
+
+  const pieces = specialRequests
+    .split(/[\n;]+/)
+    .map((piece) => piece.trim())
+    .filter(Boolean);
+
+  if (pieces.length === 0) {
+    return [];
+  }
+
+  if (pieces.length === 1) {
+    const [label, ...rest] = pieces[0].split(':');
+    if (rest.length === 0) {
+      return [{ value: pieces[0] }];
+    }
+
+    return [
+      {
+        label: label.trim(),
+        value: rest.join(':').trim(),
+      },
+    ];
+  }
+
+  return pieces.map((piece) => {
+    const [label, ...rest] = piece.split(':');
+    if (rest.length === 0) {
+      return { value: label.trim() };
+    }
+
+    return {
+      label: label.trim(),
+      value: rest.join(':').trim(),
+    };
+  });
+};
+
 export default function TrackOrderPage() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [currentUser, setCurrentUser] = useState<any>(null);
@@ -345,212 +391,232 @@ export default function TrackOrderPage() {
                 )}
               </div>
             ) : (
-              orders.map(order => (
-                <div key={order.id} className="bg-white rounded-xl shadow-lg overflow-hidden">
-                  <div className="p-6">
-                    <div className="flex items-center justify-between mb-6">
-                      <div>
-                        <h3 className="text-xl font-bold text-gray-800">Order #{order.p2p_reference ?? order.id.slice(-8)}</h3>
-                        <p className="text-sm text-gray-600">
-                          {new Date(order.created_at).toLocaleDateString('en-US', {
-                            year: 'numeric',
-                            month: 'long',
-                            day: 'numeric',
-                            hour: '2-digit',
-                            minute: '2-digit'
-                          })}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-2xl font-bold text-pink-600">
-                          {hasPendingPrice(order)
-                            ? 'Precio pendiente'
-                            : `$${order.total.toFixed(2)}`}
-                        </p>
-                        <div className={`px-4 py-2 rounded-full text-sm font-bold border ${getStatusColor(order.status)}`}>
-                          <i className={`${getStatusIcon(order.status)} mr-2`}></i>
-                          {getStatusLabel(order.status)}
+              orders.map(order => {
+                const specialRequests = formatSpecialRequests(order.special_requests);
+
+                return (
+                  <div key={order.id} className="bg-white rounded-xl shadow-lg overflow-hidden">
+                    <div className="p-6">
+                      <div className="flex items-center justify-between mb-6">
+                        <div>
+                          <h3 className="text-xl font-bold text-gray-800">Order #{order.p2p_reference ?? order.id.slice(-8)}</h3>
+                          <p className="text-sm text-gray-600">
+                            {new Date(order.created_at).toLocaleDateString('en-US', {
+                              year: 'numeric',
+                              month: 'long',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit'
+                            })}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-2xl font-bold text-pink-600">
+                            {hasPendingPrice(order)
+                              ? 'Precio pendiente'
+                              : `$${order.total.toFixed(2)}`}
+                          </p>
+                          <div className={`px-4 py-2 rounded-full text-sm font-bold border ${getStatusColor(order.status)}`}>
+                            <i className={`${getStatusIcon(order.status)} mr-2`}></i>
+                            {getStatusLabel(order.status)}
+                          </div>
                         </div>
                       </div>
-                    </div>
 
-                    <div className="mb-6">
-                      <h4 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-                        <i className="ri-route-line text-pink-500 mr-2"></i>
-                        Order Progress
-                      </h4>
-                      <div className="relative">
-                        {(() => {
-                          const steps = getWorkflowSteps(order.status);
-                          const currentIndex = steps.findIndex(s => s.isCurrent);
-                          const progressWidth =
-                            steps.length > 1 && currentIndex >= 0
-                              ? (currentIndex / (steps.length - 1)) * 100
-                              : 0;
-                          return (
-                            <>
-                              <div className="flex items-center justify-between">
-                                {steps.map(step => (
-                                  <div key={step.key} className="flex flex-col items-center relative z-10">
-                                    <div
-                                      className={`w-12 h-12 rounded-full flex items-center justify-center border-4 ${
-                                        step.isCompleted
-                                          ? 'bg-green-500 border-green-500 text-white'
-                                          : step.isCurrent
-                                            ? 'bg-pink-500 border-pink-500 text-white animate-pulse'
-                                            : step.isActive
-                                              ? 'bg-pink-100 border-pink-300 text-pink-600'
-                                              : 'bg-gray-100 border-gray-300 text-gray-400'
-                                      }`}
-                                    >
-                                      <i className={`${step.icon} text-lg`}></i>
-                                    </div>
-                                    <p
-                                      className={`text-xs font-medium mt-2 text-center ${
-                                        step.isActive ? 'text-gray-800' : 'text-gray-400'
-                                      }`}
-                                    >
-                                      {step.label}
-                                    </p>
-                                    {step.isCurrent && (
-                                      <div className="absolute -bottom-8 bg-pink-500 text-white px-2 py-1 rounded text-xs whitespace-nowrap">
-                                        In progress
+                      <div className="mb-6">
+                        <h4 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                          <i className="ri-route-line text-pink-500 mr-2"></i>
+                          Order Progress
+                        </h4>
+                        <div className="relative">
+                          {(() => {
+                            const steps = getWorkflowSteps(order.status);
+                            const currentIndex = steps.findIndex(s => s.isCurrent);
+                            const progressWidth =
+                              steps.length > 1 && currentIndex >= 0
+                                ? (currentIndex / (steps.length - 1)) * 100
+                                : 0;
+                            return (
+                              <>
+                                <div className="flex items-center justify-between">
+                                  {steps.map(step => (
+                                    <div key={step.key} className="flex flex-col items-center relative z-10">
+                                      <div
+                                        className={`w-12 h-12 rounded-full flex items-center justify-center border-4 ${
+                                          step.isCompleted
+                                            ? 'bg-green-500 border-green-500 text-white'
+                                            : step.isCurrent
+                                              ? 'bg-pink-500 border-pink-500 text-white animate-pulse'
+                                              : step.isActive
+                                                ? 'bg-pink-100 border-pink-300 text-pink-600'
+                                                : 'bg-gray-100 border-gray-300 text-gray-400'
+                                        }`}
+                                      >
+                                        <i className={`${step.icon} text-lg`}></i>
                                       </div>
-                                    )}
-                                  </div>
-                                ))}
-                              </div>
-                              {steps.length > 1 && (
-                                <div className="absolute top-6 left-6 right-6 h-1 bg-gray-200 -z-10">
-                                  <div
-                                    className="h-full bg-gradient-to-r from-pink-400 to-green-400 transition-all duration-1000"
-                                    style={{ width: `${progressWidth}%` }}
-                                  ></div>
+                                      <p
+                                        className={`text-xs font-medium mt-2 text-center ${
+                                          step.isActive ? 'text-gray-800' : 'text-gray-400'
+                                        }`}
+                                      >
+                                        {step.label}
+                                      </p>
+                                      {step.isCurrent && (
+                                        <div className="absolute -bottom-8 bg-pink-500 text-white px-2 py-1 rounded text-xs whitespace-nowrap">
+                                          In progress
+                                        </div>
+                                      )}
+                                    </div>
+                                  ))}
                                 </div>
-                              )}
-                            </>
-                          );
-                        })()}
-                      </div>
-                    </div>
-
-                    {order.pickup_time && (
-                      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-4 mb-4 border border-blue-200">
-                        <div className="flex items-center">
-                          <div className="w-10 h-10 flex items-center justify-center bg-blue-100 rounded-full mr-3">
-                            <i className="ri-calendar-line text-blue-600"></i>
-                          </div>
-                          <div>
-                            <p className="font-semibold text-blue-800">Pickup Time</p>
-                            <p className="text-blue-700">{order.pickup_time}</p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    <div className="mb-4">
-                      <h4 className="text-sm font-bold text-gray-700 mb-3 flex items-center">
-                        <i className="ri-shopping-bag-line text-pink-500 mr-2"></i>
-                        Your Order Items
-                      </h4>
-                      <div className="bg-gray-50 rounded-xl p-4 space-y-3">
-                        {order.items.map((item, idx) => (
-                          <div key={idx} className="flex justify-between items-start space-x-3">
-                            <div className="flex items-start space-x-3">
-                              <div className="w-8 h-8 bg-pink-100 rounded-full flex items-center justify-center text-pink-600 font-bold text-sm">
-                                {item.quantity}
-                              </div>
-                              <div>
-                                <span className="font-medium text-gray-700 block">{item.name}</span>
-                                {item.details && (
-                                  <p className="text-xs text-gray-500 whitespace-pre-line mt-1">{item.details}</p>
+                                {steps.length > 1 && (
+                                  <div className="absolute top-6 left-6 right-6 h-1 bg-gray-200 -z-10">
+                                    <div
+                                      className="h-full bg-gradient-to-r from-pink-400 to-green-400 transition-all duration-1000"
+                                      style={{ width: `${progressWidth}%` }}
+                                    ></div>
+                                  </div>
                                 )}
+                              </>
+                            );
+                          })()}
+                        </div>
+                      </div>
+
+                      {order.pickup_time && (
+                        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-4 mb-4 border border-blue-200">
+                          <div className="flex items-center">
+                            <div className="w-10 h-10 flex items-center justify-center bg-blue-100 rounded-full mr-3">
+                              <i className="ri-calendar-line text-blue-600"></i>
+                            </div>
+                            <div>
+                              <p className="font-semibold text-blue-800">Pickup Time</p>
+                              <p className="text-blue-700">{order.pickup_time}</p>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                        <div className="mb-4">
+                          <h4 className="text-sm font-bold text-gray-700 mb-3 flex items-center">
+                            <i className="ri-shopping-bag-line text-pink-500 mr-2"></i>
+                            Your Order Items
+                          </h4>
+                        <div className="bg-gray-50 rounded-xl p-4 space-y-3">
+                          {order.items.map((item, idx) => (
+                            <div key={idx} className="flex justify-between items-start space-x-3">
+                              <div className="flex items-start space-x-3">
+                                <div className="w-8 h-8 bg-pink-100 rounded-full flex items-center justify-center text-pink-600 font-bold text-sm">
+                                  {item.quantity}
+                                </div>
+                                <div>
+                                  <span className="font-medium text-gray-700 block">{item.name}</span>
+                                  {item.details && (
+                                    <p className="text-xs text-gray-500 whitespace-pre-line mt-1">{item.details}</p>
+                                  )}
+                                </div>
+                              </div>
+                              <span className="font-bold text-gray-800">{formatItemPrice(item)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+
+                      {specialRequests.length > 0 && (
+                        <div className="mb-4 p-4 bg-gradient-to-r from-yellow-50 to-amber-50 rounded-xl border-l-4 border-yellow-400">
+                          <div className="flex items-start space-x-3">
+                            <i className="ri-lightbulb-line text-yellow-600 mt-0.5"></i>
+                            <div>
+                              <p className="font-bold text-yellow-800">Special Requests:</p>
+                              <ul className="mt-2 space-y-1 text-sm">
+                                {specialRequests.map((entry, idx) => (
+                                  <li key={`${order.id}-special-${idx}`} className="flex items-start">
+                                    <span className="mt-1 mr-2 text-yellow-500">•</span>
+                                    <div className="text-yellow-700">
+                                      {entry.label ? (
+                                        <span>
+                                          <span className="font-medium text-yellow-800">{entry.label}:</span>{' '}
+                                          {entry.value}
+                                        </span>
+                                      ) : (
+                                        entry.value
+                                      )}
+                                    </div>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="border-t pt-4 space-y-2 text-sm">
+                        {hasPendingPrice(order) ? (
+                          <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-800">
+                            <div className="flex items-start space-x-3">
+                              <i className="ri-hourglass-2-line mt-0.5 text-lg"></i>
+                              <div>
+                                <p className="font-semibold">Precio pendiente de aprobación</p>
+                                <p className="text-xs text-amber-700">
+                                  La panadería está revisando tu orden. Te avisaremos cuando el precio esté listo para realizar el pago.
+                                </p>
                               </div>
                             </div>
-                            <span className="font-bold text-gray-800">{formatItemPrice(item)}</span>
                           </div>
-                        ))}
-                      </div>
-                    </div>
-
-                    {order.special_requests && (
-                      <div className="mb-4 p-4 bg-gradient-to-r from-yellow-50 to-amber-50 rounded-xl border-l-4 border-yellow-400">
-                        <div className="flex items-start space-x-3">
-                          <i className="ri-lightbulb-line text-yellow-600 mt-0.5"></i>
-                          <div>
-                            <p className="font-bold text-yellow-800">Special Requests:</p>
-                            <p className="text-yellow-700">{order.special_requests}</p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    <div className="border-t pt-4 space-y-2 text-sm">
-                      {hasPendingPrice(order) ? (
-                        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-800">
-                          <div className="flex items-start space-x-3">
-                            <i className="ri-hourglass-2-line mt-0.5 text-lg"></i>
-                            <div>
-                              <p className="font-semibold">Precio pendiente de aprobación</p>
-                              <p className="text-xs text-amber-700">
-                                La panadería está revisando tu orden. Te avisaremos cuando el precio esté listo para realizar el pago.
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      ) : (
-                        <>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600">Subtotal:</span>
-                            <span>${order.subtotal.toFixed(2)}</span>
-                          </div>
-                          {order.tax > 0 && (
+                        ) : (
+                          <>
                             <div className="flex justify-between">
-                              <span className="text-gray-600">Impuestos:</span>
-                              <span>${order.tax.toFixed(2)}</span>
+                              <span className="text-gray-600">Subtotal:</span>
+                              <span>${order.subtotal.toFixed(2)}</span>
                             </div>
-                          )}
-                          <div className="flex justify-between font-bold text-lg border-t pt-2">
-                            <span>Total:</span>
-                            <span className="text-pink-600">${order.total.toFixed(2)}</span>
+                            {order.tax > 0 && (
+                              <div className="flex justify-between">
+                                <span className="text-gray-600">Impuestos:</span>
+                                <span>${order.tax.toFixed(2)}</span>
+                              </div>
+                            )}
+                            <div className="flex justify-between font-bold text-lg border-t pt-2">
+                              <span>Total:</span>
+                              <span className="text-pink-600">${order.total.toFixed(2)}</span>
+                            </div>
+                          </>
+                        )}
+                      </div>
+
+                      {order.payment_status === 'pending' && !hasPendingPrice(order) && (
+                        <div className="mt-4">
+                          <a
+                            href={`/order?orderId=${order.id}`}
+                            className="block w-full text-center bg-gradient-to-r from-pink-500 to-purple-500 text-white py-2 rounded-lg font-bold"
+                          >
+                            Pagar ${order.total.toFixed(2)}
+                          </a>
+                        </div>
+                      )}
+
+                      {order.status === 'ready' && (
+                        <div className="mt-4 p-4 bg-gradient-to-r from-green-500 to-emerald-500 rounded-xl text-white text-center">
+                          <div className="flex items-center justify-center mb-2">
+                            <i className="ri-check-double-line text-2xl mr-2"></i>
+                            <span className="font-bold text-lg">Your order is ready!</span>
                           </div>
-                        </>
+                          <p className="text-green-100">You can come pick it up whenever you like</p>
+                        </div>
+                      )}
+
+                      {order.status === 'completed' && (
+                        <div className="mt-4 p-4 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-xl text-white text-center">
+                          <div className="flex items-center justify-center mb-2">
+                            <i className="ri-gift-line text-2xl mr-2"></i>
+                            <span className="font-bold text-lg">Order completed!</span>
+                          </div>
+                          <p className="text-blue-100">Thank you for choosing our bakery</p>
+                        </div>
                       )}
                     </div>
-
-                    {order.payment_status === 'pending' && !hasPendingPrice(order) && (
-                      <div className="mt-4">
-                        <a
-                          href={`/order?orderId=${order.id}`}
-                          className="block w-full text-center bg-gradient-to-r from-pink-500 to-purple-500 text-white py-2 rounded-lg font-bold"
-                        >
-                          Pagar ${order.total.toFixed(2)}
-                        </a>
-                      </div>
-                    )}
-
-                    {order.status === 'ready' && (
-                      <div className="mt-4 p-4 bg-gradient-to-r from-green-500 to-emerald-500 rounded-xl text-white text-center">
-                        <div className="flex items-center justify-center mb-2">
-                          <i className="ri-check-double-line text-2xl mr-2"></i>
-                          <span className="font-bold text-lg">Your order is ready!</span>
-                        </div>
-                        <p className="text-green-100">You can come pick it up whenever you like</p>
-                      </div>
-                    )}
-
-                    {order.status === 'completed' && (
-                      <div className="mt-4 p-4 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-xl text-white text-center">
-                        <div className="flex items-center justify-center mb-2">
-                          <i className="ri-gift-line text-2xl mr-2"></i>
-                          <span className="font-bold text-lg">Order completed!</span>
-                        </div>
-                        <p className="text-blue-100">Thank you for choosing our bakery</p>
-                      </div>
-                    )}
                   </div>
-                </div>
-              ))
+                );
+              })
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- parse and normalize special request text so it can be displayed as labeled entries
- render special requests in the order tracker as a bullet list with emphasized labels for clarity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db0eae2e088327895ffbf26203cbac