### PR TITLE
Add automated notifications for order lifecycle updates

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -936,44 +936,6 @@ const initSquareCard = useCallback(async () => {
         console.log('No se pudo notificar al negocio sobre la orden personalizada:', notificationError);
       }
 
-      try {
-        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-        if (supabaseUrl) {
-          await fetch(`${supabaseUrl}/functions/v1/send-notification-email`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
-            },
-            body: JSON.stringify({
-              to: 'rangerbakery@gmail.com',
-              type: 'business_new_order',
-              language: 'es',
-              orderData: {
-                id: insertedOrder.id || finalReference,
-                status: insertedOrder.status || 'pending',
-                customer_name: customerName,
-                customer_phone: customerPhone,
-                customer_email: customerEmail || null,
-                pickup_time: formData.pickupTime || null,
-                special_requests: orderPayload.special_requests,
-                subtotal: orderPayload.subtotal,
-                tax: orderPayload.tax,
-                total: orderPayload.total,
-                items: cartItems.map((item) => ({
-                  name: item.name,
-                  quantity: item.quantity,
-                  price: getItemPrice(item),
-                })),
-                payment_method: 'manual_quote',
-              },
-            }),
-          });
-        }
-      } catch (notificationError) {
-        console.log('Error enviando notificación de orden personalizada:', notificationError);
-      }
-
       if (customerEmail) {
         try {
           const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/lib/orderNotifications.ts
+++ b/lib/orderNotifications.ts
@@ -19,54 +19,92 @@ export interface OrderNotificationPayload {
   paymentMethod?: string;
 }
 
-export async function notifyBusinessAboutOrder(payload: OrderNotificationPayload) {
+interface OrderNotificationResultDetail {
+  recipient: string;
+  success: boolean;
+  error?: string;
+}
+
+interface OrderNotificationResult {
+  success: boolean;
+  error?: string;
+  details?: OrderNotificationResultDetail[];
+}
+
+export async function notifyBusinessAboutOrder(payload: OrderNotificationPayload): Promise<OrderNotificationResult> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const businessEmail =
     process.env.NEXT_PUBLIC_BUSINESS_NOTIFICATION_EMAIL || 'rangerbakery@gmail.com';
+  const employeeEmails = (process.env.NEXT_PUBLIC_EMPLOYEE_NOTIFICATION_EMAILS || '')
+    .split(',')
+    .map(email => email.trim())
+    .filter(Boolean);
 
   if (!supabaseUrl || !anonKey) {
     console.warn('Missing Supabase configuration for order notifications');
     return { success: false, error: 'Supabase configuration missing' };
   }
 
-  try {
-    const response = await fetch(`${supabaseUrl}/functions/v1/send-notification-email`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${anonKey}`,
-      },
-      body: JSON.stringify({
-        to: businessEmail,
-        type: 'business_new_order',
-        language: 'es',
-        orderData: {
-          id: payload.id,
-          status: payload.status,
-          customer_name: payload.customerName,
-          customer_phone: payload.customerPhone,
-          customer_email: payload.customerEmail,
-          pickup_time: payload.pickupTime,
-          special_requests: payload.specialRequests,
-          subtotal: payload.subtotal,
-          tax: payload.tax,
-          total: payload.total,
-          items: payload.items,
-          payment_method: payload.paymentMethod,
-        },
-      }),
-    });
+  const recipients = Array.from(new Set([businessEmail, ...employeeEmails]));
 
-    const result = await response.json();
+  const results = await Promise.all(
+    recipients.map(async (recipient) => {
+      try {
+        const response = await fetch(`${supabaseUrl}/functions/v1/send-notification-email`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${anonKey}`,
+          },
+          body: JSON.stringify({
+            to: recipient,
+            type: 'business_new_order',
+            language: 'es',
+            orderData: {
+              id: payload.id,
+              status: payload.status,
+              customer_name: payload.customerName,
+              customer_phone: payload.customerPhone,
+              customer_email: payload.customerEmail,
+              pickup_time: payload.pickupTime,
+              special_requests: payload.specialRequests,
+              subtotal: payload.subtotal,
+              tax: payload.tax,
+              total: payload.total,
+              items: payload.items,
+              payment_method: payload.paymentMethod,
+            },
+          }),
+        });
 
-    if (!response.ok || !result?.success) {
-      throw new Error(result?.error || 'Failed to send business notification email');
-    }
+        const result = await response.json();
 
-    return { success: true };
-  } catch (error: any) {
-    console.error('Error sending business order notification:', error);
-    return { success: false, error: error?.message || 'Unknown error' };
+        if (!response.ok || !result?.success) {
+          throw new Error(result?.error || 'Failed to send business notification email');
+        }
+
+        return { recipient, success: true };
+      } catch (error: any) {
+        console.error(`Error sending business notification to ${recipient}:`, error);
+        return { recipient, success: false, error: error?.message || 'Unknown error' };
+      }
+    })
+  );
+
+  const failedRecipients = results.filter((result) => !result.success);
+
+  if (failedRecipients.length > 0) {
+    const errorMessage = `Failed to notify: ${failedRecipients
+      .map(({ recipient }) => recipient)
+      .join(', ')}`;
+
+    return {
+      success: false,
+      error: errorMessage,
+      details: results,
+    };
   }
+
+  return { success: true, details: results };
 }


### PR DESCRIPTION
## Summary
- notify all configured business recipients when a new order is created
- email customers when order pricing is approved and when orders are marked ready for pickup
- expand the notification edge function with payment/pickup templates and URL fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db1fb7b00c832789bdf899e9f0bb70