### PR TITLE
Clarify primary contact phone label and rename flavor label

### DIFF
--- a/app/cakes/[id]/CakeCustomizer.tsx
+++ b/app/cakes/[id]/CakeCustomizer.tsx
@@ -735,7 +735,7 @@ export default function CakeCustomizer({ cakeId }: CakeCustomizerProps) {
     const summaryParts = [
       selectedOptions.shape ? `Forma: ${shapeOptions.find(s => s.id === selectedOptions.shape)?.name}` : null,
       layerDescriptions ? `Capas: ${layerDescriptions}` : null,
-      flavorNames ? `Sabores: ${flavorNames}` : null,
+      flavorNames ? `Masa: ${flavorNames}` : null,
       selectedOptions.colors.length ? `Colores: ${selectedOptions.colors.map(id => colorOptions.find(c => c.id === id)?.name).filter(Boolean).join(', ')}` : null,
       customizerMode === 'advanced' && selectedOptions.fillings.length
         ? `Rellenos: ${selectedOptions.fillings.map(id => fillingOptions.find(f => f.id === id)?.name).filter(Boolean).join(', ')}`

--- a/app/dashboard/CalendarView.tsx
+++ b/app/dashboard/CalendarView.tsx
@@ -221,7 +221,10 @@ export default function CalendarView({ orders, onStatusUpdate }: CalendarViewPro
                         <h4 className="font-bold text-gray-800">{order.customer_name}</h4>
                         <div className="flex items-center space-x-2 text-sm text-gray-600">
                           <i className="ri-phone-line"></i>
-                          <span>{order.customer_phone}</span>
+                          <span>
+                            <span className="font-medium">Teléfono principal:</span>{' '}
+                            {order.customer_phone}
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/app/dashboard/OrderCard.tsx
+++ b/app/dashboard/OrderCard.tsx
@@ -190,7 +190,10 @@ export default function OrderCard({ order, onStatusChange }: OrderCardProps) {
             <div className="space-y-1 text-sm text-gray-600">
               <div className="flex items-center">
                 <i className="ri-phone-line mr-2 w-4"></i>
-                <span>{order.customer_phone}</span>
+                <span>
+                  <span className="font-medium">Teléfono principal:</span>{' '}
+                  {order.customer_phone}
+                </span>
               </div>
               {order.customer_email && (
                 <div className="flex items-center">

--- a/app/dashboard/orders/[id]/print/page.tsx
+++ b/app/dashboard/orders/[id]/print/page.tsx
@@ -134,7 +134,8 @@ export default function PrintOrderPage({ params }: { params: { id: string } }) {
             <span className="font-semibold text-gray-900">Cliente:</span> {order.customer_name}
           </p>
           <p>
-            <span className="font-semibold text-gray-900">Teléfono:</span> {order.customer_phone}
+            <span className="font-semibold text-gray-900">Teléfono (contacto principal):</span>{' '}
+            {order.customer_phone}
           </p>
           {order.customer_email && (
             <p>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1389,7 +1389,10 @@ export default function DashboardPage() {
                                 <div>
                                   <p className="text-sm font-semibold text-gray-600">Cliente</p>
                                   <p className="text-lg font-bold text-gray-900">{order.customer_name}</p>
-                                  <p className="text-sm text-gray-500">{order.customer_phone}</p>
+                                  <p className="text-sm text-gray-500">
+                                    <span className="font-medium">Teléfono principal:</span>{' '}
+                                    {order.customer_phone}
+                                  </p>
                                 </div>
                                 <div className="text-right">
                                   <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Total</p>
@@ -1979,7 +1982,10 @@ function QuoteCard({ quote, onStatusUpdate, onFinalize, onDelete }: { quote: Quo
           <div className="flex items-center space-x-4 text-sm text-gray-600">
             <div className="flex items-center">
               <i className="ri-phone-line mr-1"></i>
-              <span>{quote.customer_phone}</span>
+              <span>
+                <span className="font-medium">Teléfono principal:</span>{' '}
+                {quote.customer_phone}
+              </span>
             </div>
             {quote.customer_email && (
               <div className="flex items-center">

--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -382,7 +382,7 @@ useEffect(() => {
       details.push(`Niveles: ${customization.layers}`);
     }
     if (customization.flavors) {
-      details.push(`Sabores: ${customization.flavors}`);
+      details.push(`Masa: ${customization.flavors}`);
     }
     if (customization.colors) {
       details.push(`Colores: ${customization.colors}`);

--- a/lib/orderItemFormatting.ts
+++ b/lib/orderItemFormatting.ts
@@ -13,7 +13,7 @@ export interface FormattedItemDetail {
 const CUSTOMIZATION_LABELS: Record<string, { label: string; emphasis?: boolean; allowMultiline?: boolean }> = {
   shape: { label: 'Forma' },
   layers: { label: 'Capas' },
-  flavors: { label: 'Sabores' },
+  flavors: { label: 'Masa' },
   colors: { label: 'Colores' },
   fillings: { label: 'Rellenos' },
   decorations: { label: 'Decoraciones' },


### PR DESCRIPTION
## Summary
- label customer phone numbers as the primary contact across dashboard views and printable order pages
- rename the cake flavor field from "Sabores" to "Masa" in order summaries and customization details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd47ad4e88327b8df094867264ab2