### PR TITLE
Document email notification configuration

### DIFF
--- a/.env
+++ b/.env
@@ -20,3 +20,12 @@ NEXT_PUBLIC_SQUARE_ENV="production"
 
 # CORS configuration
 ALLOWED_ORIGIN="http://localhost:3000"
+
+# Email notifications
+NEXT_PUBLIC_BUSINESS_NOTIFICATION_EMAIL="orders@rangersbakery.com"
+NEXT_PUBLIC_EMPLOYEE_NOTIFICATION_EMAILS="team@rangersbakery.com"
+
+# Supabase Edge Function (send-notification-email)
+# Set these via `supabase secrets set` in production deployments.
+PUBLIC_APP_BASE_URL="https://app.rangersbakery.com"
+RESEND_API_KEY="your-resend-api-key"


### PR DESCRIPTION
## Summary
- add missing email notification environment variables to the sample `.env`
- document the order notification flow and required Supabase secrets for Resend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4da8e21483278f85bcf31a07d2c8