### PR TITLE
Eliminate local storage fallbacks in favor of Supabase persistence

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useLanguage } from '../../lib/languageContext';
 import { supabase } from '../../lib/supabase';
-import { saveUser } from '../../lib/authStorage';
 import Header from '../../components/Header';
 import TabBar from '../../components/TabBar';
 
@@ -75,24 +74,6 @@ export default function AuthPage() {
 
           // Determinar rol y permisos desde el servidor
           const userRole = profile?.role || 'customer';
-          const isOwner = userRole === 'owner';
-
-          const userPhone = (profile?.phone || data.user.user_metadata?.phone || '').toString().trim();
-
-          const userData = {
-            id: data.user.id,
-            email: normalizedEmail, // Usar email normalizado
-            fullName: profile?.full_name || data.user.user_metadata?.full_name || normalizedEmail.split('@')[0],
-            phone: userPhone || undefined,
-            isOwner: isOwner,
-            role: userRole,
-            loginTime: Date.now()
-          };
-
-          // Guardar usuario sanitisado en localStorage con expiración
-          saveUser(userData);
-
-          console.log('👤 Usuario autenticado:', userData);
 
           // Redirigir según el rol
           if (userRole === 'owner' || userRole === 'employee') {

--- a/app/menu/MenuSection.tsx
+++ b/app/menu/MenuSection.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { showCartNotification } from '../../lib/cartNotification';
 import SafeImage from '@/components/SafeImage';
 import { useLanguage } from '../../lib/languageContext';
+import { supabase } from '../../lib/supabase';
 
 interface MenuItem {
   name: string;
@@ -22,7 +23,7 @@ export default function MenuSection({ category, items }: MenuSectionProps) {
   const { t } = useLanguage();
 
   useEffect(() => {
-    checkAuthentication();
+    void checkAuthentication();
 
     const initialQuantities: { [key: string]: number } = {};
     items.forEach(item => {
@@ -31,9 +32,16 @@ export default function MenuSection({ category, items }: MenuSectionProps) {
     setQuantities(initialQuantities);
   }, [items]);
 
-  const checkAuthentication = () => {
-    const userData = localStorage.getItem('bakery-user');
-    setIsAuthenticated(!!userData);
+  const checkAuthentication = async () => {
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setIsAuthenticated(!!session);
+    } catch (error) {
+      console.error('Error verificando autenticación:', error);
+      setIsAuthenticated(false);
+    }
   };
 
   const updateQuantity = (itemName: string, change: number) => {

--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -135,24 +135,11 @@ useEffect(() => {
 
       const currentProfilePhone = (currentUser?.phone || '').trim();
       if (currentProfilePhone === trimmedPhone) {
-        if (typeof window !== 'undefined') {
-          try {
-            const storedRaw = localStorage.getItem('bakery-user');
-            if (storedRaw) {
-              const stored = JSON.parse(storedRaw);
-              if (stored.phone !== trimmedPhone) {
-                localStorage.setItem('bakery-user', JSON.stringify({ ...stored, phone: trimmedPhone }));
-              }
-            }
-          } catch {
-            // ignore storage errors
-          }
-        }
         return;
       }
 
-      try {
-        if (currentUser?.id) {
+      if (currentUser?.id) {
+        try {
           const { error } = await supabase
             .from('profiles')
             .update({ phone: trimmedPhone, updated_at: new Date().toISOString() })
@@ -163,36 +150,12 @@ useEffect(() => {
           } else {
             setCurrentUser((prev: any) => (prev ? { ...prev, phone: trimmedPhone } : prev));
           }
-        } else if (typeof window !== 'undefined') {
-          const storedRaw = localStorage.getItem('bakery-user');
-          if (storedRaw) {
-            try {
-              const stored = JSON.parse(storedRaw);
-              localStorage.setItem('bakery-user', JSON.stringify({ ...stored, phone: trimmedPhone }));
-            } catch {
-              // ignore
-            }
-          }
+        } catch (error) {
+          console.warn('Error inesperado al actualizar el teléfono del perfil:', error);
         }
-      } catch (error) {
-        console.warn('Error inesperado al actualizar el teléfono del perfil:', error);
+      } else {
+        setCurrentUser((prev: any) => (prev ? { ...prev, phone: trimmedPhone } : prev));
       }
-
-      if (typeof window !== 'undefined') {
-        try {
-          const storedRaw = localStorage.getItem('bakery-user');
-          if (storedRaw) {
-            const stored = JSON.parse(storedRaw);
-            if (stored.phone !== trimmedPhone) {
-              localStorage.setItem('bakery-user', JSON.stringify({ ...stored, phone: trimmedPhone }));
-            }
-          }
-        } catch {
-          // ignore storage errors
-        }
-      }
-
-      setCurrentUser((prev: any) => (prev ? { ...prev, phone: trimmedPhone } : prev));
     },
     [currentUser]
   );
@@ -517,12 +480,6 @@ const initSquareCard = useCallback(async () => {
         if (profile) {
           setCurrentUser(profile);
         }
-      } else {
-        const localUser = localStorage.getItem('bakery-user');
-        if (localUser) {
-          const userData = JSON.parse(localUser);
-          setCurrentUser(userData);
-        }
       }
     } catch (error) {
       console.log('Error checking user:', error);
@@ -737,22 +694,6 @@ const initSquareCard = useCallback(async () => {
               .eq('id', user.id);
 
             setCurrentUser((prev: any) => (prev ? { ...prev, ...contactUpdates } : prev));
-          }
-        } else if (providedEmail || providedPhone) {
-          const localUserRaw = localStorage.getItem('bakery-user');
-          if (localUserRaw) {
-            try {
-              const localUser = JSON.parse(localUserRaw);
-              const updatedUser = {
-                ...localUser,
-                ...(providedEmail ? { email: providedEmail } : {}),
-                ...(providedPhone ? { phone: providedPhone } : {}),
-              };
-              localStorage.setItem('bakery-user', JSON.stringify(updatedUser));
-              setCurrentUser((prev: any) => (prev ? { ...prev, ...updatedUser } : updatedUser));
-            } catch {
-              // Ignore local storage parse errors
-            }
           }
         }
       } catch (profileUpdateError) {


### PR DESCRIPTION
## Summary
- rely exclusively on Supabase for profile editing, password recovery metadata, and dashboard user management instead of local storage caches
- remove local order replicas by loading, updating, and deleting orders directly from Supabase and surfacing sync errors in the dashboard and tracking page
- update authentication, menu, and order flows to verify sessions with Supabase and persist contact details there while keeping the cart cached locally only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc4d9186288327a6b4bfe54fc21dd3