### PR TITLE
Fix missing access token when creating P2P order

### DIFF
--- a/app/order/OrderForm.tsx
+++ b/app/order/OrderForm.tsx
@@ -1169,7 +1169,8 @@ const initSquareCard = useCallback(async () => {
 
       const { data: { session } } = await supabase.auth.getSession();
       const userId = session?.user?.id;
-      if (!userId) {
+      const accessToken = session?.access_token;
+      if (!userId || !accessToken) {
         throw new Error('User not authenticated');
       }
 


### PR DESCRIPTION
## Summary
- retrieve the Supabase session access token before creating a Zelle P2P order
- ensure the Zelle order flow throws an authentication error when the token is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc66c408108327a708f3378e46a140