### PR TITLE
Normalize order item detail parsing

### DIFF
--- a/lib/orderItemFormatting.ts
+++ b/lib/orderItemFormatting.ts
@@ -41,7 +41,21 @@ export const extractItemDetails = (item: ItemWithCustomization): FormattedItemDe
       .split(/\n+/)
       .map(line => line.trim())
       .filter(Boolean)
-      .forEach(line => pushUnique({ value: line }));
+      .forEach(line => {
+        const separatorIndex = line.indexOf(':');
+
+        if (separatorIndex > -1) {
+          const rawLabel = line.slice(0, separatorIndex).trim();
+          const rawValue = line.slice(separatorIndex + 1).trim();
+
+          if (isNonEmptyString(rawLabel) && isNonEmptyString(rawValue)) {
+            pushUnique({ label: rawLabel, value: rawValue });
+            return;
+          }
+        }
+
+        pushUnique({ value: line });
+      });
   }
 
   const customization = item.customization ?? null;


### PR DESCRIPTION
## Summary
- parse order item detail lines that contain colon-separated labels into structured entries
- prevent duplicates between free-form details and customization metadata in order summaries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc6d7532108327a50f86add7a6bc5c