### PR TITLE
Harden payment simulation, CORS, and auth logging

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -10,24 +10,52 @@ import TabBar from '../../components/TabBar';
 
 const isDevMode = process.env.NODE_ENV !== 'production';
 
+const sanitizeDetail = (detail: unknown) => {
+  if (!detail || typeof detail !== 'object') {
+    return detail;
+  }
+
+  if (detail instanceof Error) {
+    return {
+      name: detail.name,
+      message: detail.message,
+      status: (detail as Record<string, unknown>)?.status,
+    };
+  }
+
+  const record = detail as Record<string, unknown>;
+  const safeKeys = ['message', 'status', 'code'];
+  return safeKeys.reduce<Record<string, unknown>>((acc, key) => {
+    if (record[key] !== undefined) {
+      acc[key] = record[key];
+    }
+    return acc;
+  }, {});
+};
+
 const debugLog = (...args: unknown[]) => {
   if (isDevMode) {
-    console.log(...args);
+    console.log(...args.map(sanitizeDetail));
   }
 };
 
 const warnLog = (...args: unknown[]) => {
   if (isDevMode) {
-    console.warn(...args);
+    console.warn(...args.map(sanitizeDetail));
   }
 };
 
 const errorLog = (message: string, detail?: unknown) => {
-  if (isDevMode) {
-    console.error(message, detail);
-  } else {
-    console.error(message);
+  if (!isDevMode) {
+    return;
   }
+
+  if (detail === undefined) {
+    console.error(message);
+    return;
+  }
+
+  console.error(message, sanitizeDetail(detail));
 };
 
 export default function AuthPage() {

--- a/app/dashboard/UserManagement.tsx
+++ b/app/dashboard/UserManagement.tsx
@@ -151,10 +151,17 @@ export default function UserManagement() {
         return;
       }
 
-      const updatedRole =
-        payload && typeof payload.role === 'string' ? payload.role : newRole;
+      if (!payload || payload.success !== true || typeof payload.role !== 'string') {
+        const unexpectedDetail =
+          payload && typeof payload.error === 'string'
+            ? payload.error
+            : 'La respuesta del servidor no es válida.';
+        console.error('Respuesta inesperada al actualizar usuario:', payload);
+        alert(`No se pudo confirmar el cambio de rol: ${unexpectedDetail}`);
+        return;
+      }
 
-      alert(`Usuario actualizado a ${updatedRole} exitosamente`);
+      alert(`Usuario actualizado a ${payload.role} exitosamente`);
       await loadUsersFromDatabase();
     } catch (error) {
       console.error('Error:', error);

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,29 +1,67 @@
-const NODE_ENV = (Deno.env.get('NODE_ENV') || 'development').toLowerCase();
+const NODE_ENV = (Deno.env.get('NODE_ENV') || 'production').toLowerCase();
+
+const normalizeOrigin = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return null;
+  }
+};
+
 const rawOrigins =
   Deno.env.get('ALLOWED_ORIGINS') ?? Deno.env.get('ALLOWED_ORIGIN') ?? '';
 
-const parsedOrigins = rawOrigins
+const configuredOrigins = rawOrigins
   .split(',')
-  .map((origin) => origin.trim())
-  .filter(Boolean);
+  .map((origin) => normalizeOrigin(origin.trim()))
+  .filter((origin): origin is string => Boolean(origin));
 
-const allowAllOrigins =
-  parsedOrigins.includes('*') ||
-  (parsedOrigins.length === 0 && NODE_ENV !== 'production');
+const fallbackOriginCandidates = [
+  Deno.env.get('NEXT_PUBLIC_SITE_URL'),
+  Deno.env.get('SITE_URL'),
+  Deno.env.get('NEXT_PUBLIC_SUPABASE_URL'),
+  Deno.env.get('SUPABASE_URL'),
+];
+
+const fallbackOrigins = fallbackOriginCandidates
+  .map((origin) => normalizeOrigin(origin?.trim()))
+  .filter((origin): origin is string => Boolean(origin));
+
+const effectiveOrigins = configuredOrigins.length > 0
+  ? configuredOrigins
+  : fallbackOrigins;
+
+const allowAllOrigins = configuredOrigins.includes('*') ||
+  (configuredOrigins.length === 0 && effectiveOrigins.length === 0 && NODE_ENV !== 'production');
 
 const allowedOrigins = allowAllOrigins
   ? []
-  : Array.from(new Set(parsedOrigins));
+  : Array.from(new Set(effectiveOrigins));
 
 const corsBaseHeaders: Record<string, string> = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
+  'Vary': 'Origin',
 };
 
-const configurationError = !allowAllOrigins && allowedOrigins.length === 0
-  ? 'Missing ALLOWED_ORIGINS environment variable. Set ALLOWED_ORIGINS to a comma-separated list of trusted domains.'
-  : null;
+let configurationError: string | null = null;
+
+if (!allowAllOrigins && allowedOrigins.length === 0) {
+  configurationError =
+    'Missing ALLOWED_ORIGINS environment variable. Provide a comma-separated list of trusted domains or set NEXT_PUBLIC_SITE_URL.';
+}
+
+if (configurationError) {
+  const message = `[CORS] ${configurationError}`;
+  console.error(message);
+  if (NODE_ENV === 'production') {
+    throw new Error(message);
+  }
+}
 
 export function getCorsHeaders(origin: string | null): Record<string, string> {
   if (allowAllOrigins) {


### PR DESCRIPTION
## Summary
- require real Square credentials in production, log simulation mode explicitly, and propagate simulation flags consistently
- normalize Supabase Edge Function CORS origins with safe fallbacks and fail fast when no trusted origin is configured
- prevent false-positive role updates in the dashboard and restrict auth page logging to sanitized details in development only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc941266748327aa752d74e23d1519