### PR TITLE
Harden email templates and storage uploads

### DIFF
--- a/supabase/migrations/20241015123000_temp_uploads_policies.sql
+++ b/supabase/migrations/20241015123000_temp_uploads_policies.sql
@@ -3,13 +3,25 @@ insert into storage.buckets (id, name, public)
 values ('temp-uploads', 'temp-uploads', false)
 on conflict (id) do nothing;
 
--- Allow anyone (even unauthenticated) to upload files
--- to the temp-uploads bucket
+-- Allow authenticated uploads with basic validation to the temp-uploads bucket
 drop policy if exists "Allow public uploads to temp-uploads" on storage.objects;
-create policy "Allow public uploads to temp-uploads"
+create policy "Allow controlled uploads to temp-uploads"
   on storage.objects for insert
-  to public
-  with check (bucket_id = 'temp-uploads');
+  to authenticated, service_role
+  with check (
+    bucket_id = 'temp-uploads'
+    and (
+      auth.role() = 'service_role'
+      or (
+        owner = auth.uid()
+        and coalesce((metadata->>'size')::bigint, 0) <= 5 * 1024 * 1024
+        and (
+          coalesce(metadata->>'mimetype', '') ilike 'image/%'
+          or lower(coalesce(metadata->>'mimetype', '')) = 'application/pdf'
+        )
+      )
+    )
+  );
 
 -- Allow only owners and employees to read files
 -- from the temp-uploads bucket


### PR DESCRIPTION
## Summary
- add reusable HTML escaping helpers and sanitize notification email payloads before rendering business and customer templates, while ensuring business emails require staff authentication
- escape user-provided fields in the quote response email to prevent HTML injection in outgoing messages
- tighten the temp-uploads storage policy to require authenticated uploads with basic size and MIME validation

## Testing
- not run (edge functions)


------
https://chatgpt.com/codex/tasks/task_e_68dc9436eaa08327a6c4c2b095beb298