### PR TITLE
Fix error sanitization to handle optional status

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -16,10 +16,11 @@ const sanitizeDetail = (detail: unknown) => {
   }
 
   if (detail instanceof Error) {
+    const status = 'status' in detail ? (detail as { status?: unknown }).status : undefined;
     return {
       name: detail.name,
       message: detail.message,
-      status: (detail as Record<string, unknown>)?.status,
+      ...(status !== undefined ? { status } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary
- guard optional status property when sanitizing Error objects for logging
- avoid casting Error to a generic record to satisfy type checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0b12c9388327b6a2eb0039440b6e