### PR TITLE
Add script to deploy Supabase Edge Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Deploying Supabase Edge Functions
+
+Use the helper script to deploy all Supabase Edge Functions once you have authenticated the Supabase CLI and exported your project reference:
+
+```bash
+npm run deploy:supabase:functions
+```
+
+See [`docs/deploy-supabase-functions.md`](./docs/deploy-supabase-functions.md) for setup instructions and troubleshooting tips.
+
 ## Square payments (solo tarjeta)
 
 The project integrates [Square Web Payments SDK](https://developer.squareup.com/docs/web-payments/overview) to accept card payments. Apple Pay y Google Pay están deshabilitados temporalmente.

--- a/docs/deploy-supabase-functions.md
+++ b/docs/deploy-supabase-functions.md
@@ -1,0 +1,38 @@
+# Deploying Supabase Edge Functions
+
+This project bundles several Supabase Edge Functions inside `supabase/functions`. Use the helper script below to deploy every function in one go.
+
+## Prerequisites
+
+1. Install dependencies (the script relies on the Supabase CLI published on npm):
+   ```bash
+   npm install
+   ```
+2. Authenticate the Supabase CLI if you have not done so already:
+   ```bash
+   npx supabase login
+   ```
+   This stores an access token in `~/.supabase` and sets the `SUPABASE_ACCESS_TOKEN` environment variable for the current shell. Alternatively, export `SUPABASE_ACCESS_TOKEN` manually before running the deployment command.
+3. Export the Supabase project reference (visible in the dashboard under *Project Settings → General → Reference ID*):
+   ```bash
+   export SUPABASE_PROJECT_REF=your-project-ref
+   ```
+
+## Deploy all functions
+
+Run the script from the repository root to deploy every function directory (excluding shared utilities):
+
+```bash
+npm run deploy:supabase:functions
+```
+
+The script iterates over each folder in `supabase/functions` that does not start with an underscore (e.g. `_shared`) and calls `npx supabase functions deploy <function> --project-ref $SUPABASE_PROJECT_REF`.
+
+## Troubleshooting
+
+- Ensure that your environment exports both `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_REF`. The script will abort early if the project reference is missing, and the CLI will prompt for authentication if the access token is not available.
+- You can deploy a single function manually with:
+  ```bash
+  npx supabase functions deploy send-notification-email --project-ref "$SUPABASE_PROJECT_REF"
+  ```
+- If you need to supply additional secrets, run `supabase secrets set` prior to deployment as described in [`docs/supabase-function-secrets.md`](./supabase-function-secrets.md).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "deploy:supabase:functions": "node scripts/deploy-supabase-functions.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -27,6 +28,7 @@
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.2.18"
+    "eslint-config-next": "14.2.18",
+    "supabase": "^1.219.5"
   }
 }

--- a/scripts/deploy-supabase-functions.mjs
+++ b/scripts/deploy-supabase-functions.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { readdir } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRef = process.env.SUPABASE_PROJECT_REF;
+const accessToken = process.env.SUPABASE_ACCESS_TOKEN;
+
+if (!projectRef) {
+  console.error('❌ Missing SUPABASE_PROJECT_REF environment variable.');
+  console.error('   Set it to your Supabase project reference before running this script.');
+  process.exit(1);
+}
+
+if (!accessToken) {
+  console.error('⚠️  SUPABASE_ACCESS_TOKEN is not set. The Supabase CLI will prompt for login or fail if no access token is available.');
+}
+
+const functionsDir = join(__dirname, '..', 'supabase', 'functions');
+
+let directories;
+try {
+  directories = await readdir(functionsDir, { withFileTypes: true });
+} catch (error) {
+  console.error(`❌ Unable to read functions directory at ${functionsDir}:`, error);
+  process.exit(1);
+}
+
+const functions = directories
+  .filter((entry) => entry.isDirectory() && !entry.name.startsWith('_'))
+  .map((entry) => entry.name)
+  .sort();
+
+if (functions.length === 0) {
+  console.log('No Supabase Edge Functions found to deploy.');
+  process.exit(0);
+}
+
+console.log(`Deploying ${functions.length} Supabase Edge Function(s) to project ${projectRef}...`);
+
+for (const functionName of functions) {
+  console.log(`\n🚀 Deploying function: ${functionName}`);
+  await new Promise((resolve, reject) => {
+    const child = spawn(
+      process.platform === 'win32' ? 'npx.cmd' : 'npx',
+      ['supabase', 'functions', 'deploy', functionName, '--project-ref', projectRef],
+      { stdio: 'inherit', env: process.env }
+    );
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Deployment failed for function ${functionName} with exit code ${code}`));
+      }
+    });
+  }).catch((error) => {
+    console.error(`❌ ${error.message}`);
+    process.exit(1);
+  });
+}
+
+console.log('\n✅ All Supabase Edge Functions deployed successfully.');


### PR DESCRIPTION
## Summary
- add an npm script that iterates over Supabase Edge Function directories and deploys each one with the CLI
- document the deployment workflow and reference it from the README for easy discovery
- include the Supabase CLI npm package so `npx supabase` is available during deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df096a6ee4832792d75c1cdbeb7a8d