### PR TITLE
Document CORS setup for google reviews function

### DIFF
--- a/components/Reviews.tsx
+++ b/components/Reviews.tsx
@@ -171,6 +171,7 @@ export default function Reviews() {
           <ul className="list-disc pl-5 space-y-1 text-sm">
             <li>{t('reviewsSetupStepApiKey')}</li>
             <li>{t('reviewsSetupStepPlaceId')}</li>
+            <li>{t('reviewsSetupStepAllowedOrigins')}</li>
             <li>{t('reviewsSetupStepDeploy')}</li>
           </ul>
           <p className="text-xs mt-3">{t('reviewsSetupViewDocs')}</p>

--- a/docs/google-reviews-setup.md
+++ b/docs/google-reviews-setup.md
@@ -32,7 +32,9 @@ This guide explains how to display Google reviews inside the Rangers Bakery webs
 3. Add the following variables:
    - `GOOGLE_PLACES_API_KEY` – the API key created in the previous step.
    - `GOOGLE_PLACES_PLACE_ID` – the Place ID from section 2.
+   - `ALLOWED_ORIGINS` – the public URLs that can call the function (for example, `https://rangersbakery.com,https://preview.rangersbakery.com`).
    - *(Optional)* `GOOGLE_BUSINESS_NAME` – the display name you prefer to show in logs.
+   > **Tip:** If you prefer, you can instead define `NEXT_PUBLIC_SITE_URL` or `SITE_URL` with the same public URL. The CORS logic will fall back to those values when `ALLOWED_ORIGINS` is missing.
 4. Redeploy the function so the new environment variables are available:
    ```bash
    supabase functions deploy google-reviews

--- a/docs/supabase-function-secrets.md
+++ b/docs/supabase-function-secrets.md
@@ -18,6 +18,8 @@ Set these first—they allow each Edge Function to talk to Supabase securely and
 | `NODE_ENV` | Controls environment-sensitive defaults (e.g., logging, allowed origins). | All functions.【F:supabase/functions/send-quote-response/index.ts†L9-L33】【F:supabase/functions/send-notification-email/index.ts†L12-L43】【F:supabase/functions/google-reviews/index.ts†L3-L35】 |
 | `ALLOWED_ORIGINS` | Comma-separated list of trusted domains for browser calls; falls back to `*` outside production. | All HTTP handlers.【F:supabase/functions/send-quote-response/index.ts†L1-L44】【F:supabase/functions/send-notification-email/index.ts†L1-L46】【F:supabase/functions/google-reviews/index.ts†L1-L34】 |
 
+> **Tip:** Set `ALLOWED_ORIGINS` to the public URLs that should reach your functions (for example, `https://rangersbakery.com,https://preview.rangersbakery.com`). If you skip it, the CORS helper tries `NEXT_PUBLIC_SITE_URL` or `SITE_URL` as fallbacks before allowing requests.
+
 ## 2. Square payments
 Required for the `square-payment` function and any frontend requests that create Square orders.
 

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -140,6 +140,8 @@ export const translations = {
       "Agrega GOOGLE_PLACES_API_KEY en las variables de entorno del Edge Function google-reviews.",
     reviewsSetupStepPlaceId:
       "Agrega GOOGLE_PLACES_PLACE_ID con el Place ID oficial de la panadería.",
+    reviewsSetupStepAllowedOrigins:
+      "Configura ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) con la URL pública del sitio.",
     reviewsSetupStepDeploy:
       "Vuelve a desplegar el Edge Function google-reviews después de guardar los cambios.",
     reviewsSetupViewDocs: "Consulta docs/google-reviews-setup.md para la guía paso a paso.",
@@ -345,6 +347,8 @@ export const translations = {
       "Add GOOGLE_PLACES_API_KEY to the google-reviews Edge Function environment variables.",
     reviewsSetupStepPlaceId:
       "Add GOOGLE_PLACES_PLACE_ID with the bakery's official Place ID.",
+    reviewsSetupStepAllowedOrigins:
+      "Set ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) to the site's public URL.",
     reviewsSetupStepDeploy:
       "Redeploy the google-reviews Edge Function after saving the environment variables.",
     reviewsSetupViewDocs: "See docs/google-reviews-setup.md for the step-by-step guide.",


### PR DESCRIPTION
## Summary
- document the need to configure ALLOWED_ORIGINS (or site URL fallbacks) for the google-reviews function
- update the shared secrets guide with guidance on allowed origins fallbacks
- surface the new setup step in both Spanish and English UI copy for the reviews setup helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05579edcc83279a239f5179be0958