### PR TITLE
Allow GET requests in CORS helper

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -42,7 +42,7 @@ const allowedOrigins = allowAllOrigins
   : Array.from(new Set(effectiveOrigins));
 
 const corsBaseHeaders: Record<string, string> = {
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
   'Vary': 'Origin',


### PR DESCRIPTION
## Summary
- include GET in the Access-Control-Allow-Methods header within the shared CORS helper so browser preflight requests succeed for GET calls

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0573057d08327897bc2ab1fd87987