### PR TITLE
Improve Google reviews guidance and auth headers

### DIFF
--- a/components/Reviews.tsx
+++ b/components/Reviews.tsx
@@ -60,6 +60,8 @@ export default function Reviews() {
   const [corsError, setCorsError] = useState(false);
   const [currentOrigin, setCurrentOrigin] = useState('');
   const [apiError, setApiError] = useState(false);
+  const [missingSupabaseAnonKey, setMissingSupabaseAnonKey] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   const fetchGoogleReviews = useCallback(async () => {
     try {
@@ -68,10 +70,13 @@ export default function Reviews() {
       setMissingSupabaseUrl(false);
       setApiError(false);
       setCorsError(false);
+      setMissingSupabaseAnonKey(false);
+      setErrorMessage('');
 
       // Simulando delay de API para mostrar loading
       await new Promise(resolve => setTimeout(resolve, 1000));
       const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
       if (!supabaseUrl) {
         setMissingSupabaseUrl(true);
@@ -82,8 +87,21 @@ export default function Reviews() {
         return;
       }
 
+      if (!supabaseAnonKey) {
+        setMissingSupabaseAnonKey(true);
+        setSetupRequired(true);
+        setReviews([]);
+        setTotalReviews(0);
+        setAverageRating(0);
+        return;
+      }
+
       const response = await fetch(`${supabaseUrl}/functions/v1/google-reviews`, {
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: supabaseAnonKey,
+          Authorization: `Bearer ${supabaseAnonKey}`,
+        },
       });
 
       const data = await response.json().catch(() => null);
@@ -105,6 +123,10 @@ export default function Reviews() {
         setSetupRequired(true);
       }
 
+      if (typeof data?.message === 'string' && data.message.trim().length > 0) {
+        setErrorMessage(data.message);
+      }
+
       if (data?.setupRequired) {
         setSetupRequired(true);
       } else {
@@ -118,6 +140,9 @@ export default function Reviews() {
     } catch (error) {
       console.error('Error fetching reviews:', error);
       setApiError(true);
+      if (error instanceof Error && error.message) {
+        setErrorMessage(error.message);
+      }
       setReviews([]);
       setTotalReviews(0);
       setAverageRating(0);
@@ -188,10 +213,14 @@ export default function Reviews() {
             <li>{t('reviewsSetupStepPlaceId')}</li>
             <li>{t('reviewsSetupStepAllowedOrigins')}</li>
             <li>{t('reviewsSetupStepDeploy')}</li>
+            <li>{t('reviewsSetupStepSupabaseAnonKey')}</li>
           </ul>
           <p className="text-xs mt-3">{t('reviewsSetupViewDocs')}</p>
           {missingSupabaseUrl && (
             <p className="text-xs mt-2 text-red-600">{t('reviewsSetupMissingSupabase')}</p>
+          )}
+          {missingSupabaseAnonKey && (
+            <p className="text-xs mt-2 text-red-600">{t('reviewsSetupMissingSupabaseAnonKey')}</p>
           )}
         </div>
       )}
@@ -208,8 +237,11 @@ export default function Reviews() {
       )}
 
       {apiError && !setupRequired && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6 text-red-700 text-sm">
-          {t('reviewsSetupError')}
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6 text-red-700 text-sm space-y-2">
+          <p>{t('reviewsSetupError')}</p>
+          {errorMessage && (
+            <p className="text-xs">{t('reviewsSetupErrorDetails').replace('{message}', errorMessage)}</p>
+          )}
         </div>
       )}
 
@@ -235,6 +267,9 @@ export default function Reviews() {
             <i className="ri-edit-line mr-2 text-base"></i>
             {t('writeReview')}
           </button>
+          <p className="mt-3 text-xs text-gray-500 max-w-md mx-auto">
+            {t('reviewsGoogleOnlyDisclaimer')}
+          </p>
         </div>
       </div>
 
@@ -253,6 +288,9 @@ export default function Reviews() {
               {t('shareExperience')}
               <i className="ri-arrow-right-line ml-1"></i>
             </button>
+            <p className="mt-3 text-xs text-gray-400 max-w-sm mx-auto">
+              {t('reviewsGoogleOnlyDisclaimer')}
+            </p>
           </div>
         )}
         

--- a/docs/google-reviews-setup.md
+++ b/docs/google-reviews-setup.md
@@ -52,12 +52,13 @@ This guide explains how to display Google reviews inside the Rangers Bakery webs
 ## 6. Allow customers to leave a Google review
 
 1. Edit the review link in `components/Reviews.tsx` to point to the bakery’s official Google reviews URL.
-2. When customers click **Write Review**, a new tab opens with Google’s review dialog. Google handles authentication and publishing.
+2. When customers click **Write Review**, a new tab opens with Google’s review dialog. Google handles authentication and publishing—the website cannot send a review directly to Google on behalf of the visitor.
 3. Once Google publishes the review, it will be included automatically the next time the Edge Function fetches data (the component requests fresh data whenever the page loads).
 
 ## 7. Troubleshooting tips
 
 - **No reviews appear** – Verify that both environment variables exist and have no trailing spaces. Check the Supabase Edge Function logs for details returned by Google.
+- **`401 Unauthorized`** – The website is not passing the Supabase anon key. Confirm that `NEXT_PUBLIC_SUPABASE_ANON_KEY` is defined in the web app and that the deployment is using the updated environment variable.
 - **`REQUEST_DENIED` or `API key is invalid`** – The API key is wrong, not enabled for Places API, or not allowed from the Supabase network. Adjust the key restrictions.
 - **`NOT_FOUND`** – The Place ID does not match the Google Business Profile. Repeat Section 2 to confirm the Place ID.
 - **Rate limits** – Google Places API has usage limits. If you exceed them, consider enabling billing and monitoring quotas.

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -144,15 +144,22 @@ export const translations = {
       "Configura ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) con la URL pública del sitio.",
     reviewsSetupStepDeploy:
       "Vuelve a desplegar el Edge Function google-reviews después de guardar los cambios.",
+    reviewsSetupStepSupabaseAnonKey:
+      "Asegúrate de que NEXT_PUBLIC_SUPABASE_ANON_KEY esté disponible en la web para autorizar las llamadas a Supabase.",
     reviewsSetupViewDocs: "Consulta docs/google-reviews-setup.md para la guía paso a paso.",
     reviewsSetupMissingSupabase:
       "Falta configurar NEXT_PUBLIC_SUPABASE_URL para llamar al Edge Function de Google Reviews.",
+    reviewsSetupMissingSupabaseAnonKey:
+      "Falta NEXT_PUBLIC_SUPABASE_ANON_KEY, por lo que el sitio no puede autenticar las solicitudes a Supabase.",
     reviewsSetupCorsErrorTitle: "Autoriza este sitio en el Edge Function de Google Reviews",
     reviewsSetupCorsErrorDescription:
       "Agrega {origin} a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
     reviewsSetupCorsErrorDescriptionNoOrigin:
       "Agrega la URL pública del sitio a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
     reviewsSetupError: "No pudimos cargar las reseñas de Google en este momento. Intenta de nuevo más tarde.",
+    reviewsSetupErrorDetails: "Detalles: {message}",
+    reviewsGoogleOnlyDisclaimer:
+      "Google solo acepta reseñas creadas directamente en Google. Las reseñas nuevas aparecerán aquí automáticamente cuando Google las publique.",
     
     // Common
     loading: "Cargando...",
@@ -356,15 +363,22 @@ export const translations = {
       "Set ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) to the site's public URL.",
     reviewsSetupStepDeploy:
       "Redeploy the google-reviews Edge Function after saving the environment variables.",
+    reviewsSetupStepSupabaseAnonKey:
+      "Make sure NEXT_PUBLIC_SUPABASE_ANON_KEY is available in the web app so calls to Supabase are authorized.",
     reviewsSetupViewDocs: "See docs/google-reviews-setup.md for the step-by-step guide.",
     reviewsSetupMissingSupabase:
       "NEXT_PUBLIC_SUPABASE_URL is not configured, so the site cannot call the google-reviews Edge Function.",
+    reviewsSetupMissingSupabaseAnonKey:
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY is missing, so the site cannot authenticate requests to Supabase.",
     reviewsSetupCorsErrorTitle: "Allow this site to call the google-reviews Edge Function",
     reviewsSetupCorsErrorDescription:
       "Add {origin} to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",
     reviewsSetupCorsErrorDescriptionNoOrigin:
       "Add your public site URL to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",
     reviewsSetupError: "We couldn't load Google reviews right now. Please try again later.",
+    reviewsSetupErrorDetails: "Details: {message}",
+    reviewsGoogleOnlyDisclaimer:
+      "Google only accepts reviews created directly on Google. New reviews will appear here automatically after Google publishes them.",
     
     // Common
     loading: "Loading...",


### PR DESCRIPTION
## Summary
- require the Supabase anon key when calling the google-reviews Edge Function and surface API error details in the UI
- expand review setup messaging with clearer guidance about Google-only submissions in both languages
- update the Google reviews setup guide with additional troubleshooting information about required headers and review flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e05df12d0c8327a67b62db56809b3d