### PR TITLE
Remove Google reviews setup alert

### DIFF
--- a/docs/google-reviews-setup.md
+++ b/docs/google-reviews-setup.md
@@ -52,12 +52,13 @@ This guide explains how to display Google reviews inside the Rangers Bakery webs
 ## 6. Allow customers to leave a Google review
 
 1. Edit the review link in `components/Reviews.tsx` to point to the bakery’s official Google reviews URL.
-2. When customers click **Write Review**, a new tab opens with Google’s review dialog. Google handles authentication and publishing.
+2. When customers click **Write Review**, a new tab opens with Google’s review dialog. Google handles authentication and publishing—the website cannot send a review directly to Google on behalf of the visitor.
 3. Once Google publishes the review, it will be included automatically the next time the Edge Function fetches data (the component requests fresh data whenever the page loads).
 
 ## 7. Troubleshooting tips
 
 - **No reviews appear** – Verify that both environment variables exist and have no trailing spaces. Check the Supabase Edge Function logs for details returned by Google.
+- **`401 Unauthorized`** – The website is not passing the Supabase anon key. Confirm that `NEXT_PUBLIC_SUPABASE_ANON_KEY` is defined in the web app and that the deployment is using the updated environment variable.
 - **`REQUEST_DENIED` or `API key is invalid`** – The API key is wrong, not enabled for Places API, or not allowed from the Supabase network. Adjust the key restrictions.
 - **`NOT_FOUND`** – The Place ID does not match the Google Business Profile. Repeat Section 2 to confirm the Place ID.
 - **Rate limits** – Google Places API has usage limits. If you exceed them, consider enabling billing and monitoring quotas.

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -133,26 +133,15 @@ export const translations = {
     shareExperience: "Compartir tu experiencia",
     viewOnGoogleMaps: "Ver en Google Maps",
     loadingReviews: "Cargando reseñas...",
-    reviewsSetupPendingTitle: "Integración con Google Reviews pendiente",
-    reviewsSetupPendingDescription:
-      "Para mostrar tus reseñas de Google aquí, conecta el perfil del negocio con el API de Google Places.",
-    reviewsSetupStepApiKey:
-      "Agrega GOOGLE_PLACES_API_KEY en las variables de entorno del Edge Function google-reviews.",
-    reviewsSetupStepPlaceId:
-      "Agrega GOOGLE_PLACES_PLACE_ID con el Place ID oficial de la panadería.",
-    reviewsSetupStepAllowedOrigins:
-      "Configura ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) con la URL pública del sitio.",
-    reviewsSetupStepDeploy:
-      "Vuelve a desplegar el Edge Function google-reviews después de guardar los cambios.",
-    reviewsSetupViewDocs: "Consulta docs/google-reviews-setup.md para la guía paso a paso.",
-    reviewsSetupMissingSupabase:
-      "Falta configurar NEXT_PUBLIC_SUPABASE_URL para llamar al Edge Function de Google Reviews.",
     reviewsSetupCorsErrorTitle: "Autoriza este sitio en el Edge Function de Google Reviews",
     reviewsSetupCorsErrorDescription:
       "Agrega {origin} a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
     reviewsSetupCorsErrorDescriptionNoOrigin:
       "Agrega la URL pública del sitio a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
     reviewsSetupError: "No pudimos cargar las reseñas de Google en este momento. Intenta de nuevo más tarde.",
+    reviewsSetupErrorDetails: "Detalles: {message}",
+    reviewsGoogleOnlyDisclaimer:
+      "Google solo acepta reseñas creadas directamente en Google. Las reseñas nuevas aparecerán aquí automáticamente cuando Google las publique.",
     
     // Common
     loading: "Cargando...",
@@ -345,26 +334,15 @@ export const translations = {
     shareExperience: "Share your experience",
     viewOnGoogleMaps: "View on Google Maps",
     loadingReviews: "Loading reviews...",
-    reviewsSetupPendingTitle: "Google Reviews integration pending",
-    reviewsSetupPendingDescription:
-      "Connect your Google Business Profile to the Google Places API so your reviews appear here.",
-    reviewsSetupStepApiKey:
-      "Add GOOGLE_PLACES_API_KEY to the google-reviews Edge Function environment variables.",
-    reviewsSetupStepPlaceId:
-      "Add GOOGLE_PLACES_PLACE_ID with the bakery's official Place ID.",
-    reviewsSetupStepAllowedOrigins:
-      "Set ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) to the site's public URL.",
-    reviewsSetupStepDeploy:
-      "Redeploy the google-reviews Edge Function after saving the environment variables.",
-    reviewsSetupViewDocs: "See docs/google-reviews-setup.md for the step-by-step guide.",
-    reviewsSetupMissingSupabase:
-      "NEXT_PUBLIC_SUPABASE_URL is not configured, so the site cannot call the google-reviews Edge Function.",
     reviewsSetupCorsErrorTitle: "Allow this site to call the google-reviews Edge Function",
     reviewsSetupCorsErrorDescription:
       "Add {origin} to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",
     reviewsSetupCorsErrorDescriptionNoOrigin:
       "Add your public site URL to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",
     reviewsSetupError: "We couldn't load Google reviews right now. Please try again later.",
+    reviewsSetupErrorDetails: "Details: {message}",
+    reviewsGoogleOnlyDisclaimer:
+      "Google only accepts reviews created directly on Google. New reviews will appear here automatically after Google publishes them.",
     
     // Common
     loading: "Loading...",


### PR DESCRIPTION
## Summary
- hide the Google Reviews setup reminder card so visitors no longer see the integration notice
- simplify the reviews fetch logic to silently handle missing Supabase configuration
- remove unused translation strings tied to the setup reminder copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e05df12d0c8327a67b62db56809b3d