### PR TITLE
Hide Google reviews setup instructions from clients

### DIFF
--- a/components/Reviews.tsx
+++ b/components/Reviews.tsx
@@ -56,21 +56,17 @@ export default function Reviews() {
   const [averageRating, setAverageRating] = useState(0);
   const [totalReviews, setTotalReviews] = useState(0);
   const [setupRequired, setSetupRequired] = useState(false);
-  const [missingSupabaseUrl, setMissingSupabaseUrl] = useState(false);
   const [corsError, setCorsError] = useState(false);
   const [currentOrigin, setCurrentOrigin] = useState('');
   const [apiError, setApiError] = useState(false);
-  const [missingSupabaseAnonKey, setMissingSupabaseAnonKey] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
   const fetchGoogleReviews = useCallback(async () => {
     try {
       setLoading(true);
       setSetupRequired(false);
-      setMissingSupabaseUrl(false);
       setApiError(false);
       setCorsError(false);
-      setMissingSupabaseAnonKey(false);
       setErrorMessage('');
 
       // Simulando delay de API para mostrar loading
@@ -79,7 +75,6 @@ export default function Reviews() {
       const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
       if (!supabaseUrl) {
-        setMissingSupabaseUrl(true);
         setSetupRequired(true);
         setReviews([]);
         setTotalReviews(0);
@@ -88,7 +83,6 @@ export default function Reviews() {
       }
 
       if (!supabaseAnonKey) {
-        setMissingSupabaseAnonKey(true);
         setSetupRequired(true);
         setReviews([]);
         setTotalReviews(0);
@@ -206,22 +200,7 @@ export default function Reviews() {
 
       {setupRequired && (
         <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-amber-900">
-          <h4 className="font-semibold mb-2">{t('reviewsSetupPendingTitle')}</h4>
-          <p className="text-sm mb-3">{t('reviewsSetupPendingDescription')}</p>
-          <ul className="list-disc pl-5 space-y-1 text-sm">
-            <li>{t('reviewsSetupStepApiKey')}</li>
-            <li>{t('reviewsSetupStepPlaceId')}</li>
-            <li>{t('reviewsSetupStepAllowedOrigins')}</li>
-            <li>{t('reviewsSetupStepDeploy')}</li>
-            <li>{t('reviewsSetupStepSupabaseAnonKey')}</li>
-          </ul>
-          <p className="text-xs mt-3">{t('reviewsSetupViewDocs')}</p>
-          {missingSupabaseUrl && (
-            <p className="text-xs mt-2 text-red-600">{t('reviewsSetupMissingSupabase')}</p>
-          )}
-          {missingSupabaseAnonKey && (
-            <p className="text-xs mt-2 text-red-600">{t('reviewsSetupMissingSupabaseAnonKey')}</p>
-          )}
+          <p className="text-sm">{t('reviewsSetupUnavailable')}</p>
         </div>
       )}
 

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -151,6 +151,7 @@ export const translations = {
       "Falta configurar NEXT_PUBLIC_SUPABASE_URL para llamar al Edge Function de Google Reviews.",
     reviewsSetupMissingSupabaseAnonKey:
       "Falta NEXT_PUBLIC_SUPABASE_ANON_KEY, por lo que el sitio no puede autenticar las solicitudes a Supabase.",
+    reviewsSetupUnavailable: "Las reseñas de Google estarán disponibles próximamente.",
     reviewsSetupCorsErrorTitle: "Autoriza este sitio en el Edge Function de Google Reviews",
     reviewsSetupCorsErrorDescription:
       "Agrega {origin} a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
@@ -370,6 +371,7 @@ export const translations = {
       "NEXT_PUBLIC_SUPABASE_URL is not configured, so the site cannot call the google-reviews Edge Function.",
     reviewsSetupMissingSupabaseAnonKey:
       "NEXT_PUBLIC_SUPABASE_ANON_KEY is missing, so the site cannot authenticate requests to Supabase.",
+    reviewsSetupUnavailable: "Google reviews will be available soon.",
     reviewsSetupCorsErrorTitle: "Allow this site to call the google-reviews Edge Function",
     reviewsSetupCorsErrorDescription:
       "Add {origin} to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",


### PR DESCRIPTION
## Summary
- replace the Google reviews setup callout with a simple availability message so customers do not see technical instructions
- add localized copy for the new reviews availability message in both Spanish and English

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e062100e208327a736f1a994fb6d60