### PR TITLE
Remove Google review disclaimer message

### DIFF
--- a/components/Reviews.tsx
+++ b/components/Reviews.tsx
@@ -246,9 +246,6 @@ export default function Reviews() {
             <i className="ri-edit-line mr-2 text-base"></i>
             {t('writeReview')}
           </button>
-          <p className="mt-3 text-xs text-gray-500 max-w-md mx-auto">
-            {t('reviewsGoogleOnlyDisclaimer')}
-          </p>
         </div>
       </div>
 
@@ -267,9 +264,6 @@ export default function Reviews() {
               {t('shareExperience')}
               <i className="ri-arrow-right-line ml-1"></i>
             </button>
-            <p className="mt-3 text-xs text-gray-400 max-w-sm mx-auto">
-              {t('reviewsGoogleOnlyDisclaimer')}
-            </p>
           </div>
         )}
         

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -159,8 +159,6 @@ export const translations = {
       "Agrega la URL pública del sitio a ALLOWED_ORIGINS (o NEXT_PUBLIC_SITE_URL/SITE_URL) en la configuración del Edge Function google-reviews y vuelve a desplegarlo.",
     reviewsSetupError: "No pudimos cargar las reseñas de Google en este momento. Intenta de nuevo más tarde.",
     reviewsSetupErrorDetails: "Detalles: {message}",
-    reviewsGoogleOnlyDisclaimer:
-      "Google solo acepta reseñas creadas directamente en Google. Las reseñas nuevas aparecerán aquí automáticamente cuando Google las publique.",
     
     // Common
     loading: "Cargando...",
@@ -379,8 +377,6 @@ export const translations = {
       "Add your public site URL to ALLOWED_ORIGINS (or NEXT_PUBLIC_SITE_URL/SITE_URL) in the google-reviews Edge Function settings and redeploy it.",
     reviewsSetupError: "We couldn't load Google reviews right now. Please try again later.",
     reviewsSetupErrorDetails: "Details: {message}",
-    reviewsGoogleOnlyDisclaimer:
-      "Google only accepts reviews created directly on Google. New reviews will appear here automatically after Google publishes them.",
     
     // Common
     loading: "Loading...",


### PR DESCRIPTION
## Summary
- remove the Google-only disclaimer paragraphs from the reviews component so the message no longer appears in the UI
- delete the unused translation strings associated with the disclaimer in both Spanish and English locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0650918d88327b9a018886785dcc9