### PR TITLE
Allow Supabase env fallbacks for reviews

### DIFF
--- a/components/Reviews.tsx
+++ b/components/Reviews.tsx
@@ -71,8 +71,10 @@ export default function Reviews() {
 
       // Simulando delay de API para mostrar loading
       await new Promise(resolve => setTimeout(resolve, 1000));
-      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      const supabaseUrl =
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+      const supabaseAnonKey =
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
       if (!supabaseUrl) {
         setSetupRequired(true);


### PR DESCRIPTION
## Summary
- allow the reviews widget to fall back to SUPABASE_URL/SUPABASE_ANON_KEY when NEXT_PUBLIC values are missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e066b79cac832782979b55086f61a9