### PR TITLE
Handle missing Google Reviews env vars

### DIFF
--- a/supabase/functions/google-reviews/index.ts
+++ b/supabase/functions/google-reviews/index.ts
@@ -35,8 +35,8 @@ serve(async (req) => {
   }
 
   try {
-    const apiKey = Deno.env.get('GOOGLE_PLACES_API_KEY')
-    const placeId = Deno.env.get('GOOGLE_PLACES_PLACE_ID')
+    const apiKey = (Deno.env.get('GOOGLE_PLACES_API_KEY') || '').trim()
+    const placeId = (Deno.env.get('GOOGLE_PLACES_PLACE_ID') || '').trim()
     const businessName = Deno.env.get('GOOGLE_BUSINESS_NAME') || 'Rangers Bakery'
 
     const setupInstructions = {
@@ -54,6 +54,11 @@ serve(async (req) => {
     }
 
     if (!apiKey || !placeId) {
+      console.warn('Google Reviews missing configuration', {
+        hasApiKey: Boolean(apiKey),
+        hasPlaceId: Boolean(placeId),
+        environment: Deno.env.get('SUPABASE_ENVIRONMENT') || 'unknown',
+      })
       return new Response(JSON.stringify(setupInstructions), {
         status: 400,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary
- trim the Google Places API key and place ID environment variables before validating them
- add a warning log showing whether each Google Reviews env var is present when configuration is incomplete

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0867e974083278c7732e451bf8ae4